### PR TITLE
UC7: Add Receipt/document upload functionality

### DIFF
--- a/sqlCode/database.sql
+++ b/sqlCode/database.sql
@@ -103,3 +103,28 @@ USING (
         AND role = 'treasurer'
     )
 );
+
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-- Storage Policies:
+
+-- Allow authenticated users to upload files to the files bucket
+CREATE POLICY "Authenticated users can upload files"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'files');
+
+-- Allow authenticated users to read/view files from the files bucket
+-- This is needed for generating signed URLs in UC8
+CREATE POLICY "Authenticated users can read files"
+ON storage.objects FOR SELECT
+TO authenticated
+USING (bucket_id = 'files');
+
+-- Allow authenticated users to delete files from the files bucket
+CREATE POLICY "Authenticated users can delete files"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (bucket_id = 'files');
+
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { getFiles } from '../../lib/files'
+import UploadModal from '../../components/UploadModal'
+
+// Temporary hardcoded org ID for testing, will come from auth context later
+const TEST_ORG_ID = '10148741-4cbb-4d58-977d-13fdd4398eb4'
+
+export default function FilesPage() {
+    const [files, setFiles] = useState<any[]>([])
+    const [showUpload, setShowUpload] = useState(false)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+
+    async function loadFiles() {
+        try {
+            setLoading(true)
+            const data = await getFiles(TEST_ORG_ID)
+            setFiles(data || [])
+        } catch (err) {
+            setError('Failed to load files')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => {
+        loadFiles()
+    }, [])
+
+    return (
+        <div className="p-8 max-w-4xl mx-auto">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-2xl font-semibold">Files</h1>
+                <button
+                    onClick={() => setShowUpload(true)}
+                    className="bg-blue-600 text-white px-4 py-2 rounded"
+                >
+                    Upload File
+                </button>
+            </div>
+
+            {showUpload && (
+                <UploadModal
+                    orgId={TEST_ORG_ID}
+                    onSuccess={loadFiles}
+                    onClose={() => setShowUpload(false)}
+                />
+            )}
+
+            {loading && <p className="text-black">Loading files...</p>}
+            {error && <p className="text-red-500">{error}</p>}
+            {!loading && !error && files.length === 0 && (
+                <p className="text-black">No files uploaded yet.</p>
+            )}
+
+            {!loading && !error && files.length > 0 && (
+                <ul className="divide-y border rounded-lg">
+                    {files.map((file) => (
+                        <li key={file.file_id} className="flex items-center justify-between p-4">
+                            <div>
+                                <p className="font-medium">{file.file_name}</p>
+                                <p className="text-sm text-black capitalize">
+                                    {file.file_type} · {new Date(file.uploaded_at).toLocaleDateString()}
+                                </p>
+                            </div>
+                            {/* View button will be wired up in PR3 */}
+                            <button className="text-blue-600 text-sm">View</button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { uploadFile } from '../lib/files'
+import { useState, useEffect } from 'react'
+import { uploadFile, getTransactions } from '../lib/files'
 
 // Set the properties the component will use
 type Props = {
@@ -17,6 +17,22 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
     const [fileType, setFileType] = useState<'receipt' | 'document'>('receipt')
     const [uploading, setUploading] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [transactions, setTransactions] = useState<{ transaction_id: string }[]>([])
+    const [selectedTransaction, setSelectedTransaction] = useState<string>('')
+
+    // Load transactions when the modal opens so the user can optionally link a file
+    // NOTE: dropdown labels will improve when transactions table has display fields
+    useEffect(() => {
+        async function loadTransactions() {
+            try {
+                const data = await getTransactions(orgId)
+                setTransactions(data || [])
+            } catch (err) {
+                // Silently fail, transaction linking is optional
+            }
+        }
+        loadTransactions()
+    }, [orgId])
 
     async function handleUpload() {
         if (!file) return
@@ -27,14 +43,10 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
             return
         }
 
-        // Validate file type
-        // const allowed = ['application/pdf', 'image/jpeg', 'image/png']
-        // if (!allowed.includes(file.type)) {
-        //     setError('Only PDF, JPG, and PNG files are allowed')
-        //     return
-        // }
+        // For receipts, accepted filetypes are pdf, jpeg, png
         const allowedReceipt = ['application/pdf', 'image/jpeg', 'image/png']
 
+        // For documents, accepted filetypes are pdf, jpeg, png, docx, doc, xlsx
         const allowedDocument = [
             'application/pdf',
             'image/jpeg',
@@ -58,7 +70,7 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
         setError(null)
 
         try {
-            await uploadFile(file, orgId, fileType, transactionId)
+            await uploadFile(file, orgId, fileType, selectedTransaction || undefined)
             onSuccess()
             onClose()
         } catch (err) {
@@ -71,36 +83,69 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
     return (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
             <div className="bg-white rounded-lg p-6 w-full max-w-md">
-                <h2 className="text-lg font-semibold mb-4">Upload File</h2>
+                <h2 className="text-lg font-semibold mb-4 text-black">Upload File</h2>
 
+                {/* Toggle between receipt and document */}
                 <div className="flex gap-4 mb-4">
                     <button
                         onClick={() => setFileType('receipt')}
-                        className={`flex-1 py-2 rounded border ${fileType === 'receipt' ? 'bg-blue-600 text-white' : 'border-gray-300'}`}
+                        className={`flex-1 py-2 rounded border ${fileType === 'receipt' ? 'bg-blue-600 text-white' : 'border-gray-300 text-black'}`}
                     >
                         Receipt
                     </button>
                     <button
                         onClick={() => setFileType('document')}
-                        className={`flex-1 py-2 rounded border ${fileType === 'document' ? 'bg-blue-600 text-white' : 'border-gray-300'}`}
+                        className={`flex-1 py-2 rounded border ${fileType === 'document' ? 'bg-blue-600 text-white' : 'border-gray-300 text-black'}`}
                     >
                         Document
                     </button>
                 </div>
 
+                {/* Optional transaction linking for both receipts and documents */}
+                {/* NOTE: transaction labels will improve when transaction table has display fields */}
+                <div className="mb-4">
+                    <label className="block text-sm text-black mb-1">
+                        Link to Transaction (optional)
+                    </label>
+                    <select
+                        value={selectedTransaction}
+                        onChange={(e) => setSelectedTransaction(e.target.value)}
+                        className="w-full border border-gray-300 rounded p-2 text-black"
+                    >
+                        <option value="">No transaction</option>
+                        {transactions.map((t) => (
+                            <option key={t.transaction_id} value={t.transaction_id}>
+                                {t.transaction_id}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                {/* Hidden file input triggered by the label below */}
                 <input
+                    id="file-input"
                     type="file"
-                    accept=".pdf,.jpg,.jpeg,.png"
+                    accept={fileType === 'receipt'
+                        ? '.pdf,.jpg,.jpeg,.png'
+                        : '.pdf,.jpg,.jpeg,.png,.docx,.doc,.xlsx'}
                     onChange={(e) => setFile(e.target.files?.[0] || null)}
-                    className="w-full mb-4"
+                    className="hidden"
                 />
+
+                {/* Clicking this label opens the file picker */}
+                <label
+                    htmlFor="file-input"
+                    className="block w-full mb-4 p-4 border-2 border-dashed border-gray-300 rounded text-center cursor-pointer hover:border-blue-400 text-black"
+                >
+                    {file ? file.name : 'Click to choose a file'}
+                </label>
 
                 {error && <p className="text-red-500 text-sm mb-4">{error}</p>}
 
                 <div className="flex gap-3">
                     <button
                         onClick={onClose}
-                        className="flex-1 py-2 rounded border border-gray-300"
+                        className="flex-1 py-2 rounded border border-gray-300 text-black"
                     >
                         Cancel
                     </button>

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,7 +1,8 @@
-import { supabase } from './supabase'
+import { createClient } from './supabase/client'
 
 // Uploads a file to the supabase storage, and to the files table
 export async function uploadFile(file: File, orgId: string, fileType: 'receipt' | 'document', transactionId?: string) {
+    const supabase = createClient()
     // Building a unique storage path for the file
     const filePath = `${orgId}/${Date.now()}_${file.name}`
 
@@ -22,8 +23,8 @@ export async function uploadFile(file: File, orgId: string, fileType: 'receipt' 
             file_name: file.name,
             file_type: fileType,
         })
-        .select().
-        single()
+        .select()
+        .single()
 
     if (dbError) throw dbError
 
@@ -32,6 +33,7 @@ export async function uploadFile(file: File, orgId: string, fileType: 'receipt' 
 
 // Gets all of the file rows for a given orgId 
 export async function getFiles(orgId: string) {
+    const supabase = createClient()
     const { data, error } = await supabase
         .from('files')
         .select('*')
@@ -45,6 +47,7 @@ export async function getFiles(orgId: string) {
 
 // Deletes a file with a given fileId and filePath from storage and from the files table
 export async function deleteFile(fileId: string, filePath: string) {
+    const supabase = createClient()
     // Delete from storage
     const { error: storageError } = await supabase.storage
         .from('files')
@@ -63,6 +66,7 @@ export async function deleteFile(fileId: string, filePath: string) {
 
 // Creates a url to the file that expires in 60 seconds
 export async function getSignedUrl(filePath: string) {
+    const supabase = createClient()
     const { data, error } = await supabase.storage
         .from('files')
         .createSignedUrl(filePath, 60)
@@ -70,4 +74,19 @@ export async function getSignedUrl(filePath: string) {
     if (error) throw error
 
     return data.signedUrl
+}
+
+// Gets all transactions for a given orgId
+// NOTE: transactions table is not fully fleshed out yet, working with the current state of it.
+// Will add further improvements to implementation later once transactions have been sorted out.
+export async function getTransactions(orgId: string) {
+    const supabase = createClient()
+    const { data, error } = await supabase
+        .from('transactions')
+        .select('transaction_id')
+        .eq('org_id', orgId)
+
+    if (error) throw error
+
+    return data
 }


### PR DESCRIPTION
## Description
Implements UC7 (Attach Receipt) — adds a /files page where treasurer-role users can upload receipt and document files, which are stored in a private Supabase Storage bucket with metadata saved to the files table.

Issue addressed: Closes #5 

---
## Changes
- Added `src/lib/files.ts` with Supabase functions for uploading, fetching, deleting files, generating signed URLs, and fetching transactions for linking
- Added `src/components/UploadModal.tsx`, a modal form with file type/size validation, receipt/document toggle, and optional transaction linking
- Added `src/app/files/page.tsx` as the `/files` route, listing all org files with an Upload File button
- Updated `sqlCode/database.sql` with Supabase Storage bucket policies for authenticated read, upload, and delete access

---
## How to Test
1. Navigate to my dr branch in your local env
2. Run 'npm run dev'
3. Log in as a user with the treasurer role at http://localhost:3000 or whichever port npm/nodejs is using (You can use email: "danilo@gm.co" | password: "123456")
4. Navigate to `/files`
6. Click "Upload File", optionally select a transaction to link the file upload to, select a file (PDF, JPG, or PNG for receipts; PDF, JPG, PNG, DOCX, DOC, or XLSX for documents), and click Upload
7. Confirm the file appears in the list on the page, in the [Supabase Storage bucket](https://supabase.com/dashboard/project/rdzovwebfyusnnkzvtnf/storage/files), and as a row in the [files table](https://supabase.com/dashboard/project/rdzovwebfyusnnkzvtnf/editor/59377) in Supabase.

---
## Screenshots
<img width="1361" height="710" alt="image" src="https://github.com/user-attachments/assets/a2d3ab74-c687-47f5-9b99-7ec2599a7719" />
<img width="1115" height="619" alt="image" src="https://github.com/user-attachments/assets/bba3a87e-275c-4ee5-8f37-7384378da694" />

---
## Checklist
- [X] Tested locally
- [X] No errors in console

---
## Notes
`TEST_ORG_ID` in `files/page.tsx` is hardcoded temporarily and needs to be replaced with real auth context once that is wired up across the app. 
The transaction dropdown currently displays UUIDs as labels — this will improve once the transactions table has display fields (UC5/UC6). 
The View button on each file row is a placeholder pending UC8 implementation in the next PR.
This will likely have some merge conflicts once Keith's open PR gets merged, will fix those as they arise