### PR TITLE
PR #2: UC10: Added Table Display for Audit Log

### DIFF
--- a/src/app/audit/action.ts
+++ b/src/app/audit/action.ts
@@ -9,7 +9,6 @@ export type LogEntry = {
     userId: string;
     action: "CREATE" | "UPDATE" | "DELETE";
     entity: string;
-    entityId: string;
     before_data?: any;
     after_data?: any;
 }
@@ -26,7 +25,6 @@ export async function logAuditEntry(entry: LogEntry){
         user_id: entry.userId,
         action: entry.action,
         entity: entry.entity,
-        entity_id: entry.entityId,
         before_data: entry.before_data || null,
         after_data: entry.after_data || null,
     }

--- a/src/app/audit/page.tsx
+++ b/src/app/audit/page.tsx
@@ -2,45 +2,159 @@
 
 import { useState, useEffect } from "react";
 import { logAuditEntry, LogEntry } from "./action";
+import { createClient } from "@/lib/supabase/client";
 
-// This is a temporary hardcoded org ID from files/page.tsx for testing purposes.
-// You can use a different org ID, just make sure it exists in the organizations table.
-const TEST_ORG_ID = '10148741-4cbb-4d58-977d-13fdd4398eb4'
 
-// This is a temporary hardcoded user ID for testing purposes.
-// This user ID belongs to 
-// Display Name: JimmyRings
-// you can change it to your user ID if you like.
-const TEST_USER_ID = "9e3c6b5a-e9ce-4285-b6c4-5db7fc1d737d" 
 
 export default function AuditPage(){
+    const [userId, setUserId] = useState<string | null>(null);
+    const [orgId, setOrgId] = useState<string | null>(null);
+    const [entity, setEntity] = useState("");
+    const [entityId, setEntityId] = useState("");
+    const [actionType, setActionType] = useState<"CREATE" | "UPDATE" | "DELETE">("CREATE");
+    const [beforeData, setBeforeData] = useState("");
+    const [afterData, setAfterData] = useState("");
     const [message, setMessage] = useState("");
+    const [logs, setLogs] = useState<any[]>([]);
+
+    const supabase = createClient();
+
+
+    // Fetch the user id
+    useEffect(() => {
+        const getUser = async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session?.user?.id) {
+        console.log("Current userId from session:", session.user.id);
+        setUserId(session.user.id);
+        }
+    };
+        getUser();
+    }, []);
+
+    // Fetch the orgId for this user from org_members
+    useEffect(() => {
+        const fetchOrg = async () => {
+            if(!userId) return;
+
+            const { data, error} = await supabase
+            .from("org_members")
+            .select("org_id")
+            .eq("user_id", userId)
+            .single();
+
+            if (error) console.error("Error fetching orgId", error);
+            else {
+                console.log("Fetched orgId:", data?.org_id);
+                if (data?.org_id) setOrgId(data.org_id);
+            else console.warn("No org_id found for this user in org_members table");
+            }
+        };
+        fetchOrg();
+    }, [userId, supabase])
+
+    // Fetch the latest audit log data
+    useEffect(() => {
+        if (!orgId) return;
+
+        const fetchLogs = async () => {
+            const {data, error} = await supabase
+            .from("audit_logs")
+            .select("*, users (display_name)")
+            .eq("org_id", orgId)
+            .order("created_at", {ascending: false})
+            .limit(10);
+
+            if (data) {
+                setLogs(data);
+            }
+            else if (error){ 
+                console.error("Error fetching audit logs:", error);
+            }
+        };
+        fetchLogs();
+    }, [orgId, supabase]);
     
+    // Inserts entries into the audit log
+    // This is used only for testing, will be removed in completed implementation
+    // Audit logs will only view changes from other tables
     const handleLogEntry = async () => {
-        const dummyEntry: LogEntry = {
-            orgId: TEST_ORG_ID, 
-            userId: TEST_USER_ID, // Replace with actual user ID from auth context when available
-            action: "CREATE",
-            entity: "TestEntity",
-            entityId: "33333333-3333-3333-3333-333333333333",
-            before_data: null,
-            after_data: null,
+        let beforeParsed, afterParsed;
+
+        try {
+            beforeParsed = beforeData ? JSON.parse(beforeData) : undefined;
+            afterParsed = afterData ? JSON.parse(afterData) : undefined;
+        } catch (error){
+            setMessage("Invalid JSON in before/after data");
+        }
+        
+        const entry: LogEntry = {
+            orgId: orgId!, 
+            userId: userId!, 
+            action: actionType,
+            entity,
+            before_data: beforeParsed,
+            after_data: afterParsed,
         };
 
         try{
-            await logAuditEntry(dummyEntry);
-            setMessage("Audit entry logged successfully. Check console for details.");
-        }
-        catch(error){
-            setMessage("Faild to log audit entry.");
+            await logAuditEntry(entry);
+            setMessage("Audit entry logged successfully.");
+
+            const { data } = await supabase
+            .from("audit_logs")
+            .select("*, users (display_name)")
+            .eq("org_id", orgId)
+            .order("created_at", { ascending: false })
+            .limit(10);
+
+            if (data) setLogs(data);
+        
+        }   catch(error: any){
+            setMessage("Faild to log audit entry." + error.message);
         }
     };
 
     return(
         <div style = {{ padding: "20px" }}>
-            <h1>Audit Log Test</h1>
-            <button onClick={handleLogEntry}>Log Audit Entry</button>
+            <h1>Audit Log Test Page</h1>
+            <div>
+                <input placeholder="Entity" value={entity} onChange={e => setEntity(e.target.value)}/>
+                <input placeholder="Entity ID" value={entityId} onChange={e => setEntityId(e.target.value)} />
+                <select value={actionType} onChange={e => setActionType(e.target.value as "CREATE" | "UPDATE" | "DELETE")}>
+                    <option value="CREATE">CREATE</option>
+                    <option value="UPDATE">UPDATE</option>
+                    <option value="DELETE">DELETE</option>
+                </select>
+                <input placeholder="Before Data (JSON)" value={beforeData} onChange={e => setBeforeData(e.target.value)} />
+                <input placeholder="After Data (JSON)" value={afterData} onChange={e => setAfterData(e.target.value)} />
+                <button onClick={handleLogEntry}>Log Audit Entry</button>
+            </div>
             <p>{message}</p>
+
+            <h2>Recent Audit Entries</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Date</th>
+                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>User</th>
+                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Action</th>
+                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Entity</th>
+                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Entity ID</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {logs.map(log => (
+                        <tr key={log.audit_id}>
+                            <td style={{ padding: "8px" }}>{new Date(log.created_at).toISOString().split("T")[0]}</td>
+                            <td style={{ padding: "8px" }}>{log.users?.display_name || "Unknown User"}</td>
+                            <td style={{ padding: "8px" }}>{log.action}</td>
+                            <td style={{ padding: "8px" }}>{log.entity}</td>
+                            <td style={{ padding: "8px" }}>{log.entity_id}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
         </div>
     );
 }


### PR DESCRIPTION
## Description
Added a table display for the audit log page. 

---

## Changes
- Updated `src/app/audit/page.tsx` by adding a table to display logs of the current user's organization
- Updated `src/app/audit/action.ts` which removes the entity_id entry insertion (temporary removal)

---

## How to Test
1. Run `npm run dev`
2. log into a user account (navigate to `/register` if you don't have a user account)
3. Navigate to `/organizations/new` and create a new organization to tie a org_id to your user_id (skip this if your user already has an org_id in `org_members` table)
4. Navigate to `/audit` 
5. Verify that recent logs are displaying. If no logs are displaying, type something into the `Entity` field and click on `Log Audit Entry`

---

## Screenshots
<img width="2294" height="625" alt="Screenshot 2026-03-27 000108" src="https://github.com/user-attachments/assets/2be2489c-78e0-4f64-8e57-5a1bde6e1362" />

---

## Checklist
- [x] Tested locally
- [x] No errors in console