### PR TITLE
PR #3 UC10: Updated Table Display for Audit Log

### DIFF
--- a/src/app/audit/action.ts
+++ b/src/app/audit/action.ts
@@ -3,14 +3,15 @@
 import { createClient } from "@/lib/supabase/server";
 
 // List of fields required for an audit log entry
-// This type checks that the correct data is passed to the logAuditEntry function.
+// This type checks to ensure the correct data is passed to the logAuditEntry function.
 export type LogEntry = {
     orgId: string;
     userId: string;
     action: "CREATE" | "UPDATE" | "DELETE";
-    entity: string;
-    before_data?: any;
-    after_data?: any;
+    entity_type: string;
+    entity_id: string;
+    before_data?: Record<string, any>;
+    after_data?: Record<string, any>;
 }
 
 // Server action to log an audit entry
@@ -24,9 +25,10 @@ export async function logAuditEntry(entry: LogEntry){
         org_id: entry.orgId,
         user_id: entry.userId,
         action: entry.action,
-        entity: entry.entity,
-        before_data: entry.before_data || null,
-        after_data: entry.after_data || null,
+        entity: entry.entity_type,
+        entity_id: entry.entity_id,
+        before_data: entry.before_data ?? null,
+        after_data: entry.after_data ?? null,
     }
     ]);
 

--- a/src/app/audit/page.tsx
+++ b/src/app/audit/page.tsx
@@ -1,25 +1,55 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { logAuditEntry, LogEntry } from "./action";
+import React, { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// getDiff
+// Compares before and after objects and
+// returns only the fields that have changed
+//
+// Responsibilities:
+// - field: property name
+// - oldValue: value from the before object (or "-" if undefined)
+// - newValue: value from the after object (or "-" if undefined) 
 
+function getDiff(before: any, after: any) {
+    const beforeObj = before ?? {};
+    const afterObj = after ?? {};
+
+  const fields = new Set([...Object.keys(beforeObj), ...Object.keys(afterObj)]);
+  const changes = [];
+
+  for (const field of fields) {
+    if (beforeObj[field] !== afterObj[field]) {
+      changes.push({
+        field,
+        oldValue: beforeObj[field] ?? "-",
+        newValue: afterObj[field] ?? "-",
+      });
+    }
+  }
+
+  return changes;
+}
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// AuditPage
+// Responsibilities:
+// - Fetch the current user and their organization
+// - Query audit logs for transactions within the organization
+// - Determine each user's role for display
+// - Render the audit data in a structured table
 
 export default function AuditPage(){
     const [userId, setUserId] = useState<string | null>(null);
     const [orgId, setOrgId] = useState<string | null>(null);
-    const [entity, setEntity] = useState("");
-    const [entityId, setEntityId] = useState("");
-    const [actionType, setActionType] = useState<"CREATE" | "UPDATE" | "DELETE">("CREATE");
-    const [beforeData, setBeforeData] = useState("");
-    const [afterData, setAfterData] = useState("");
-    const [message, setMessage] = useState("");
     const [logs, setLogs] = useState<any[]>([]);
+    const [role, setRole] = useState<string | null>(null);
 
     const supabase = createClient();
 
-
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Fetch the user id
     useEffect(() => {
         const getUser = async () => {
@@ -32,6 +62,7 @@ export default function AuditPage(){
         getUser();
     }, []);
 
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Fetch the orgId for this user from org_members
     useEffect(() => {
         const fetchOrg = async () => {
@@ -53,15 +84,16 @@ export default function AuditPage(){
         fetchOrg();
     }, [userId, supabase])
 
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Fetch the latest audit log data
     useEffect(() => {
         if (!orgId) return;
-
         const fetchLogs = async () => {
             const {data, error} = await supabase
             .from("audit_logs")
             .select("*, users (display_name)")
             .eq("org_id", orgId)
+            .eq("entity", "transaction")
             .order("created_at", {ascending: false})
             .limit(10);
 
@@ -74,87 +106,161 @@ export default function AuditPage(){
         };
         fetchLogs();
     }, [orgId, supabase]);
-    
-    // Inserts entries into the audit log
-    // This is used only for testing, will be removed in completed implementation
-    // Audit logs will only view changes from other tables
-    const handleLogEntry = async () => {
-        let beforeParsed, afterParsed;
 
-        try {
-            beforeParsed = beforeData ? JSON.parse(beforeData) : undefined;
-            afterParsed = afterData ? JSON.parse(afterData) : undefined;
-        } catch (error){
-            setMessage("Invalid JSON in before/after data");
-        }
-        
-        const entry: LogEntry = {
-            orgId: orgId!, 
-            userId: userId!, 
-            action: actionType,
-            entity,
-            before_data: beforeParsed,
-            after_data: afterParsed,
-        };
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Fetch the roles
+    useEffect(() => {
+        const fetchRoles = async () => {
+            if(!orgId || !userId) return;
 
-        try{
-            await logAuditEntry(entry);
-            setMessage("Audit entry logged successfully.");
-
-            const { data } = await supabase
-            .from("audit_logs")
-            .select("*, users (display_name)")
+            const{ data, error} = await supabase
+            .from("org_members")
+            .select("role")
             .eq("org_id", orgId)
-            .order("created_at", { ascending: false })
-            .limit(10);
+            .eq("user_id", userId)
+            .single();
 
-            if (data) setLogs(data);
-        
-        }   catch(error: any){
-            setMessage("Faild to log audit entry." + error.message);
-        }
+            if(data){
+                setRole(data.role);
+            } else if (error) {
+                console.error("Error fetching role:", error);
+            }
+        };
+        fetchRoles();
+    }, [orgId, userId, supabase])
+    
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Table Styles
+    // - cellStyle: base style for all table cells
+    // - boldCellStyle: same as cellStyle with bold font
+    // - specialCellStyle: style for cell without top border (used for row-spanned cells)
+    // - headerStyle: style applied to table headers
+    // - containerStyle: outer wrapper around the table
+    // - tableStyle: style applied to the table itself
+
+    const cellStyle: React.CSSProperties = {
+        border: "1px solid #374151",
+        padding: "10px",
+        borderTop: "2px solid #d1d5db",
     };
 
-    return(
-        <div style = {{ padding: "20px" }}>
-            <h1>Audit Log Test Page</h1>
-            <div>
-                <input placeholder="Entity" value={entity} onChange={e => setEntity(e.target.value)}/>
-                <input placeholder="Entity ID" value={entityId} onChange={e => setEntityId(e.target.value)} />
-                <select value={actionType} onChange={e => setActionType(e.target.value as "CREATE" | "UPDATE" | "DELETE")}>
-                    <option value="CREATE">CREATE</option>
-                    <option value="UPDATE">UPDATE</option>
-                    <option value="DELETE">DELETE</option>
-                </select>
-                <input placeholder="Before Data (JSON)" value={beforeData} onChange={e => setBeforeData(e.target.value)} />
-                <input placeholder="After Data (JSON)" value={afterData} onChange={e => setAfterData(e.target.value)} />
-                <button onClick={handleLogEntry}>Log Audit Entry</button>
-            </div>
-            <p>{message}</p>
+    const boldCellStyle: React.CSSProperties = {
+        border: "1px solid #374151",
+        padding: "10px",
+        borderTop: "2px solid #d1d5db",
+        fontWeight: "500",
+    };
 
-            <h2>Recent Audit Entries</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Date</th>
-                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>User</th>
-                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Action</th>
-                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Entity</th>
-                        <th style={{ borderBottom: "1px solid black", textAlign: "left", padding: "8px" }}>Entity ID</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {logs.map(log => (
-                        <tr key={log.audit_id}>
-                            <td style={{ padding: "8px" }}>{new Date(log.created_at).toISOString().split("T")[0]}</td>
-                            <td style={{ padding: "8px" }}>{log.users?.display_name || "Unknown User"}</td>
-                            <td style={{ padding: "8px" }}>{log.action}</td>
-                            <td style={{ padding: "8px" }}>{log.entity}</td>
-                            <td style={{ padding: "8px" }}>{log.entity_id}</td>
+    const specialCellStyle: React.CSSProperties = {
+        border: "1px solid #374151",
+        padding: "10px",
+    };
+
+    const headerStyle = {
+        border: "1px solid #e5e7eb",
+        backgroundColor: "#111827",
+        textAlign: "left" as const,
+        padding: "12px",
+        fontWeight: "600",
+    };
+    
+    const containerStyle = {
+        border: "1px solid #e5e7eb",
+        borderRadius: "8px",
+        overflow: "hidden",
+        boxShadow: "0 2px 6px rgba(0,0,0,0.05)",
+    };
+
+    const tabelStyle = {
+        width: "100%",
+        borderCollapse: "collapse" as const,
+        fontSize: "14px",
+    };
+
+
+    return(
+        <div style={{padding: "20px"}}>
+
+            {/* Page Title */}
+            <h2 style={{marginBottom: "10px"}}>Recent Audit</h2>
+
+            {/* Container around the table*/}
+            <div style={containerStyle}>
+                <table style={tabelStyle}>
+
+                    {/* Table header row */}
+                    <thead>
+                        <tr>
+                            {/* Column headers */}
+                            <th style={headerStyle}>Data</th>
+                            <th style={headerStyle}>User</th>
+                            <th style={headerStyle}>Role</th>
+                            <th style={headerStyle}>Action</th>
+                            <th style={headerStyle}>Item</th>
+                            <th style={headerStyle}>Field</th>
+                            <th style={headerStyle}>Old Value</th>
+                            <th style={headerStyle}>New Value</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
+                    </thead>
+
+                    <tbody>
+                        {/* Loop through each audit log entry */}
+                        {logs.map((log, logIndex) => {
+                            const diffs = getDiff(log.before_data, log.after_data);
+                            return diffs.map((diff, index) => (
+                                <tr
+                                key={`${log.audit_id}-${index}`}
+
+                                // Alternate row colors
+                                 style={{backgroundColor: logIndex % 2 === 0 ? "#111827" : "#1f2637",}}>
+
+                                    {/* Renders cell once per log and merges multiple diff rows using rowSpan */}
+                                    {index === 0 && (
+                                        <>
+                                            {/* Date */}
+                                            <td rowSpan={diffs.length} style={boldCellStyle}>
+                                                {new Date(log.created_at).toLocaleDateString()}
+                                            </td>
+                                            
+                                            {/* User */}
+                                            <td rowSpan={diffs.length} style={cellStyle}>
+                                                {log.users?.display_name || "Unknown User"}
+                                            </td>
+
+                                            {/* Role */}
+                                            <td rowSpan={diffs.length} style={cellStyle}>
+                                                {role}
+                                            </td>
+
+                                            {/* Action */}
+                                            <td rowSpan={diffs.length} style={cellStyle}>
+                                                {log.action}
+                                            </td>
+
+                                            {/* Item */}
+                                            <td rowSpan={diffs.length} style={cellStyle}>
+                                                {log.entity}-{log.entity_id.slice(0, 8)}
+                                            </td>
+                                        </>
+                                    )}
+
+                                    {/* These cells change per diff, they could contain more than one value to display */}
+                                    {/* Field */}
+                                    <td style={specialCellStyle}>{diff.field}</td>
+
+                                    {/* Old Value */}
+                                    <td style={specialCellStyle}>{diff.oldValue === "-" ? "—" : String(diff.oldValue)}</td>
+
+                                    {/* New Value */}
+                                    <td style={specialCellStyle}>{diff.newValue === "-" ? "—" : String(diff.newValue)}</td>
+                                 </tr>
+                            ));
+                        })}
+                    </tbody>
+                </table>
+            </div>
         </div>
     );
+
 }


### PR DESCRIPTION
## Description
Improves audit log table readability with updated styling and layout.

---

## Changes
- Updated `src/app/audit/page.tsx` to improve the readability of the table.
- Updated `src/app/audit/action.ts` which adds entity_id table insertions

---

## How to Test
1. Run `npm run dev`
2. Log in to a user that has a table entry in the `audit_logs` table. If you do not have a user with a table entry in `audit_logs`, then you could log into user: JimmyRings using `Email: halo5sucks@gmail.com` and `Password: halo123`
3. Navigate to `/audit`
4. Verify that the table renders correctly

---

## Screenshots
<img width="2552" height="487" alt="Screenshot 2026-03-27 234849" src="https://github.com/user-attachments/assets/5e0bf8f8-b96f-4ace-98a7-4e28f45f66d0" />


---

## Checklist
<!-- Mark with an X -->
- [x] Tested locally
- [x] No errors in console

---
## Note
The Audit Log page does not support manual insertions of entries since they are supposed to be automatically generated through transaction-related actions.