### PR TITLE
UC3 PR2 - add member by email and role

### DIFF
--- a/sqlCode/database.sql
+++ b/sqlCode/database.sql
@@ -209,6 +209,25 @@ CREATE TRIGGER on_auth_user_created
 
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+-- One-time backfill for users that exist in auth.users
+-- but are missing from public.users.
+--
+-- This matters because the members page reads from public.users
+-- for display name + email. If older accounts never got copied over,
+-- they show up as Unknown User / Unknown Email.
+
+INSERT INTO public.users (user_id, email, display_name)
+SELECT
+    auth_user.id,
+    auth_user.email,
+    COALESCE(auth_user.raw_user_meta_data->>'display_name', split_part(auth_user.email, '@', 1))
+FROM auth.users AS auth_user
+LEFT JOIN public.users AS public_user
+    ON public_user.user_id = auth_user.id
+WHERE public_user.user_id IS NULL;
+
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 -- Storage Policies:
 -- Same pattern as RLS — drop first since there's no IF NOT EXISTS for policies.
 

--- a/src/app/organizations/[orgId]/members/actions.ts
+++ b/src/app/organizations/[orgId]/members/actions.ts
@@ -1,33 +1,127 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
 import {
   canManageOrganizationMembers,
   getCurrentUserWithOrganizationMembership,
+  getUserByEmail,
+  isOrganizationMemberRole,
+  normalizeMemberEmail,
 } from "@/lib/organizations";
 
+// Just a small helper so redirects stay consistent and readable.
+function buildMembersPageRedirect(
+  orgId: string,
+  type: "success" | "error",
+  message: string
+) {
+  const params = new URLSearchParams({ [type]: message });
+  return `/organizations/${orgId}/members?${params.toString()}`;
+}
+
+// This keeps the manager check on the server.
+// Even if someone messes with the UI, this still protects the action.
 export async function requireOrganizationMemberManagementAccess(orgId: string) {
-  // This is the main guard for the members page.
-  // PR 1 only needs read-only viewing for authorized managers,
-  // but PR 2 can reuse this same check for mutations too.
   const { user, membership } = await getCurrentUserWithOrganizationMembership(
     orgId
   );
 
-  // Not signed in at all -> send them to login.
   if (user === null) {
     redirect("/login");
   }
 
-  // Signed in, but not part of this org -> send them away.
   if (membership === null) {
-    redirect("/organizations");
+    redirect("/organizations?error=You+are+not+part+of+that+organization.");
   }
 
-  // In the org, but wrong role for member management.
   if (!canManageOrganizationMembers(membership.role)) {
-    redirect("/organizations");
+    redirect(
+      "/organizations?error=You+do+not+have+permission+to+manage+members."
+    );
   }
 
   return membership;
+}
+
+// Server action for adding an existing user to an org.
+export async function addOrganizationMember(orgId: string, formData: FormData) {
+  await requireOrganizationMemberManagementAccess(orgId);
+
+  // Pull the raw values out of the form.
+  const email = normalizeMemberEmail(String(formData.get("email") ?? ""));
+  const role = String(formData.get("role") ?? "");
+
+  // Very basic validation. Keeping it simple on purpose.
+  if (!email) {
+    redirect(
+      buildMembersPageRedirect(orgId, "error", "Enter an email address.")
+    );
+  }
+
+  // Never trust the form role value blindly.
+  if (!isOrganizationMemberRole(role)) {
+    redirect(buildMembersPageRedirect(orgId, "error", "Invalid role."));
+  }
+
+  // PR2 only adds users that already exist in public.users.
+  const user = await getUserByEmail(email);
+
+  if (user === null) {
+    redirect(
+      buildMembersPageRedirect(
+        orgId,
+        "error",
+        "No user with that email was found."
+      )
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Check if that user is already in this org so we do not create duplicates.
+  const existingMembershipResult = await supabase
+    .from("org_members")
+    .select("user_id")
+    .eq("org_id", orgId)
+    .eq("user_id", user.user_id)
+    .maybeSingle();
+
+  if (existingMembershipResult.error) {
+    throw new Error(existingMembershipResult.error.message);
+  }
+
+  if (existingMembershipResult.data !== null) {
+    redirect(
+      buildMembersPageRedirect(
+        orgId,
+        "error",
+        "That user is already a member of this organization."
+      )
+    );
+  }
+
+  // Insert the new membership row.
+  const insertResult = await supabase.from("org_members").insert({
+    org_id: orgId,
+    user_id: user.user_id,
+    role,
+  });
+
+  if (insertResult.error) {
+    throw new Error(insertResult.error.message);
+  }
+
+  // Refresh the page data after a successful insert.
+  revalidatePath(`/organizations/${orgId}/members`);
+  revalidatePath("/organizations");
+
+  redirect(
+    buildMembersPageRedirect(
+      orgId,
+      "success",
+      `${user.email} was added as ${role.replaceAll("_", " ")}.`
+    )
+  );
 }

--- a/src/app/organizations/[orgId]/members/page.tsx
+++ b/src/app/organizations/[orgId]/members/page.tsx
@@ -2,32 +2,41 @@ import Link from "next/link";
 import {
   getOrganizationById,
   getOrganizationMembers,
+  ORGANIZATION_MEMBER_ROLE_OPTIONS,
 } from "@/lib/organizations";
-import { requireOrganizationMemberManagementAccess } from "./actions";
+import {
+  addOrganizationMember,
+  requireOrganizationMemberManagementAccess,
+} from "./actions";
 
 type MembersPageProps = {
   params: Promise<{
     orgId: string;
   }>;
+  searchParams: Promise<{
+    error?: string;
+    success?: string;
+  }>;
 };
 
 export default async function OrganizationMembersPage({
   params,
+  searchParams,
 }: MembersPageProps) {
-  // Grab the dynamic org id from the route.
-  // This page is meant to live under one specific organization.
   const { orgId } = await params;
+  const { error, success } = await searchParams;
 
-  // Before we show anything, make sure this user is actually allowed
-  // to manage members for this org. If not, the helper will redirect.
+  // Still protect the page itself, same as PR1.
   await requireOrganizationMemberManagementAccess(orgId);
 
-  // Load the org info and its members at the same time since the page
-  // needs both anyway.
+  // Load page data in parallel.
   const [organization, members] = await Promise.all([
     getOrganizationById(orgId),
     getOrganizationMembers(orgId),
   ]);
+
+  // Bind orgId once so the form can just call the action directly.
+  const addMemberForOrganization = addOrganizationMember.bind(null, orgId);
 
   return (
     <main className="min-h-screen p-6">
@@ -48,13 +57,70 @@ export default async function OrganizationMembersPage({
           </Link>
         </div>
 
+        {/* Simple success/error feedback after redirects from the server action */}
+        {success && (
+          <div className="rounded border border-green-500/50 bg-green-500/10 p-3 text-sm text-green-200">
+            {success}
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        <section className="rounded border p-4">
+          <div className="mb-4">
+            <h2 className="text-lg font-medium">Add Member</h2>
+            <p className="text-sm">
+              Add an existing TreasuryHub user to this organization by email.
+            </p>
+          </div>
+
+          <form
+            action={addMemberForOrganization}
+            className="grid gap-4 md:grid-cols-[minmax(0,1fr)_220px_auto] md:items-end"
+          >
+            <label className="flex flex-col gap-2 text-sm">
+              <span>Email</span>
+              <input
+                name="email"
+                type="email"
+                required
+                placeholder="member@example.com"
+                className="rounded border bg-transparent px-3 py-2"
+              />
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm">
+              <span>Role</span>
+              <select
+                name="role"
+                defaultValue="member"
+                className="rounded border bg-transparent px-3 py-2"
+              >
+                {ORGANIZATION_MEMBER_ROLE_OPTIONS.map((role) => (
+                  <option key={role} value={role}>
+                    {role.replaceAll("_", " ")}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <button type="submit" className="rounded border px-4 py-2">
+              Add Member
+            </button>
+          </form>
+        </section>
+
         <section className="rounded border p-4">
           <div className="mb-4 flex items-center justify-between">
             <div>
               <h2 className="text-lg font-medium">Current Members</h2>
               <p className="text-sm">
-                This PR is intentionally read-only for now. The actual add/update/remove
-                actions should go in PR 2.
+                Members already in this organization and the role they currently
+                hold.
               </p>
             </div>
           </div>
@@ -73,18 +139,17 @@ export default async function OrganizationMembersPage({
                 </thead>
                 <tbody>
                   {members.map((member) => {
-                    // If display_name is blank/null, fall back to something reasonable
-                    // so the table still looks clean.
-                    const displayName = member.users?.display_name?.trim();
-                    const email = member.users?.email ?? "Unknown email";
+                    // Prefer display name, then email, then fallback text.
+                    const displayName = member.user?.display_name?.trim();
+                    const email = member.user?.email?.trim();
 
                     return (
                       <tr key={member.user_id} className="border-b last:border-b-0">
-                        <td className="px-3 py-2">{displayName || "Unnamed User"}</td>
-                        <td className="px-3 py-2">{email}</td>
+                        <td className="px-3 py-2">
+                          {displayName || email || "Unknown User"}
+                        </td>
+                        <td className="px-3 py-2">{email || "Unknown Email"}</td>
                         <td className="px-3 py-2 capitalize">
-                          {/* Convert values like treasury_team into treasury team
-                              so the UI reads more naturally. */}
                           {member.role.replaceAll("_", " ")}
                         </td>
                       </tr>

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -17,9 +17,16 @@ type OrganizationListItem = {
   role: string;
 };
 
-export default async function Organizations() {
-  // This page is just the org selector for now.
-  // Each organization links straight to that org's members page.
+type OrganizationsPageProps = {
+  searchParams: Promise<{
+    error?: string;
+  }>;
+};
+
+export default async function Organizations({
+  searchParams,
+}: OrganizationsPageProps) {
+  const { error } = await searchParams;
   const supabase = await createClient();
 
   const whoIsUser = await supabase.auth.getUser();
@@ -29,8 +36,7 @@ export default async function Organizations() {
   let loadError = "";
 
   if (user != null) {
-    // First get the current user's memberships.
-    // We only need org_id and role here.
+    // First get the org memberships for this user.
     const membershipResult = await supabase
       .from("org_members")
       .select("org_id, role")
@@ -44,8 +50,7 @@ export default async function Organizations() {
       if (memberships.length > 0) {
         const orgIds = memberships.map((membership) => membership.org_id);
 
-        // Then load the matching organizations in a second query.
-        // This avoids the nested relation typing issue that broke the build.
+        // Then get the actual org names for those ids.
         const organizationResult = await supabase
           .from("organizations")
           .select("org_id, org_name")
@@ -55,9 +60,6 @@ export default async function Organizations() {
           loadError = organizationResult.error.message;
         } else {
           const orgRows = (organizationResult.data ?? []) as OrganizationRow[];
-
-          // Build a small lookup map so we can pair each membership
-          // with the matching organization name.
           const orgMap = new Map(
             orgRows.map((organization) => [organization.org_id, organization])
           );
@@ -99,6 +101,13 @@ export default async function Organizations() {
             </button>
           </Link>
         </div>
+
+        {/* This lets redirects from the protected members page show an actual message */}
+        {error && (
+          <p className="rounded border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-200">
+            {error}
+          </p>
+        )}
 
         {loadError && (
           <p className="text-red-500">

--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -1,12 +1,18 @@
 import { createClient } from "@/lib/supabase/server";
 
+// Keeping the allowed roles in one place so the page + server action
+// are using the same source of truth.
+export const ORGANIZATION_MEMBER_ROLE_OPTIONS = [
+  "member",
+  "executive",
+  "advisor",
+  "treasury_team",
+  "treasurer",
+  "admin",
+] as const;
+
 export type OrganizationMemberRole =
-  | "member"
-  | "executive"
-  | "advisor"
-  | "treasury_team"
-  | "treasurer"
-  | "admin";
+  (typeof ORGANIZATION_MEMBER_ROLE_OPTIONS)[number];
 
 export type OrganizationMembership = {
   user_id: string;
@@ -29,22 +35,29 @@ export type OrganizationMemberListItem = {
   user_id: string;
   org_id: string;
   role: OrganizationMemberRole;
-  users: OrganizationMemberUser | null;
+  user: OrganizationMemberUser | null;
 };
 
-type RawOrganizationMemberListItem = {
-  user_id: string;
-  org_id: string;
-  role: OrganizationMemberRole;
-  users: OrganizationMemberUser[] | null;
-};
-
-// For UC3, only treasurer and admin should be able to manage members.
-// Keeping this in one helper makes the permission rule easy to reuse later.
+// For UC3, only treasurers and admins are supposed to manage members.
 export function canManageOrganizationMembers(role: string | null | undefined) {
   return role === "treasurer" || role === "admin";
 }
 
+// Basic role validation so the server does not trust whatever comes from the form.
+export function isOrganizationMemberRole(
+  value: string | null | undefined
+): value is OrganizationMemberRole {
+  return ORGANIZATION_MEMBER_ROLE_OPTIONS.includes(
+    value as OrganizationMemberRole
+  );
+}
+
+// Normalizing email avoids dumb mismatches like uppercase letters or spaces.
+export function normalizeMemberEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+// Gets the logged-in user and also checks whether they belong to this org.
 export async function getCurrentUserWithOrganizationMembership(orgId: string) {
   const supabase = await createClient();
 
@@ -57,6 +70,7 @@ export async function getCurrentUserWithOrganizationMembership(orgId: string) {
     throw new Error(userError.message);
   }
 
+  // If no auth user exists, just return null values and let caller decide what to do.
   if (user === null) {
     return {
       user: null,
@@ -81,6 +95,7 @@ export async function getCurrentUserWithOrganizationMembership(orgId: string) {
   };
 }
 
+// Small helper for getting the org name/header info.
 export async function getOrganizationById(orgId: string) {
   const supabase = await createClient();
 
@@ -97,41 +112,67 @@ export async function getOrganizationById(orgId: string) {
   return result.data as OrganizationSummary | null;
 }
 
+// Looks up an already-existing app user by email.
+// PR2 is NOT doing invitations, so the user has to already exist.
+export async function getUserByEmail(email: string) {
+  const supabase = await createClient();
+
+  const result = await supabase
+    .from("users")
+    .select("user_id, email, display_name")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data as OrganizationMemberUser | null;
+}
+
+// Gets all org_members rows for this org, then separately loads the users.
+// This is simpler/more reliable than relying on a nested join shape.
+// It should also help with the "Unknown User" issue from PR1.
 export async function getOrganizationMembers(
   orgId: string
 ): Promise<OrganizationMemberListItem[]> {
   const supabase = await createClient();
 
-  // Supabase gives the joined users relation back as an array here,
-  // even though each org_members row should match one user.
-  // So we normalize it into a single object to keep the page code cleaner.
-  const { data: members, error } = await supabase
+  const membershipResult = await supabase
     .from("org_members")
-    .select(
-      `
-        user_id,
-        org_id,
-        role,
-        users (
-          user_id,
-          email,
-          display_name
-        )
-      `
-    )
+    .select("user_id, org_id, role")
     .eq("org_id", orgId)
     .order("role", { ascending: true });
 
-  if (error) {
-    throw new Error(error.message);
+  if (membershipResult.error) {
+    throw new Error(membershipResult.error.message);
   }
 
-  const rows = ((members ?? []) as unknown) as RawOrganizationMemberListItem[];
+  const memberships =
+    (membershipResult.data as OrganizationMembership[] | null) ?? [];
 
-  return rows.map((member) => ({
-    user_id: member.user_id,
-    org_id: member.org_id,
-    role: member.role,
-    users: member.users?.[0] ?? null,
+  if (memberships.length === 0) {
+    return [];
+  }
+
+  const userIds = memberships.map((membership) => membership.user_id);
+
+  const usersResult = await supabase
+    .from("users")
+    .select("user_id, email, display_name")
+    .in("user_id", userIds);
+
+  if (usersResult.error) {
+    throw new Error(usersResult.error.message);
+  }
+
+  const users = (usersResult.data as OrganizationMemberUser[] | null) ?? [];
+  const userMap = new Map(users.map((user) => [user.user_id, user]));
+
+  return memberships.map((membership) => ({
+    user_id: membership.user_id,
+    org_id: membership.org_id,
+    role: membership.role,
+    user: userMap.get(membership.user_id) ?? null,
   }));
 }


### PR DESCRIPTION
## Requirement
UC3

## Closes Issue
Closes #36 

## What Changed
- added an add-member form to the organization members page
- added server action logic to add an existing user to an organization by email
- added role selection during member add
- added server-side checks for:
  - unauthorized actor
  - invalid role input
  - user not found
  - duplicate org membership
- fixed the member display issue where users could show up as `Unknown User` / `Unknown Email`
- added a small SQL backfill for missing `public.users` rows

## Modules Affected
- `sqlCode/database.sql`
- `src/app/organizations/[orgId]/members/actions.ts`
- `src/app/organizations/[orgId]/members/page.tsx`
- `src/app/organizations/page.tsx`
- `src/lib/organizations.ts`

## What Was Tested
- verified treasurer/admin can add an existing user by email
- verified selected role is saved when adding a member
- verified duplicate member add is rejected
- verified unknown email is rejected
- verified invalid role input is rejected server-side
- verified unauthorized users cannot manage members
- verified existing members now display proper name/email instead of unknown fallback text

## How to Test
1. log in as a treasurer/admin
2. open `/organizations` and go to an org members page
3. add an existing user by email with a selected role
4. verify the member is added and displays correctly
5. try duplicate add and verify it is rejected
6. try unknown email and verify it is rejected
7. verify invalid role input is rejected server-side
8. verify non-managers cannot manage members
