### PR TITLE
UC3 PR3: add role updates and member removal

### DIFF
--- a/src/app/organizations/[orgId]/members/actions.ts
+++ b/src/app/organizations/[orgId]/members/actions.ts
@@ -125,3 +125,163 @@ export async function addOrganizationMember(orgId: string, formData: FormData) {
     )
   );
 }
+
+// Updates an existing member role inside the org.
+// The authorization check is server-side so the UI is not trusted.
+export async function updateOrganizationMemberRole(
+    orgId: string,
+    formData: FormData
+) {
+    const currentMembership =
+        await requireOrganizationMemberManagementAccess(orgId);
+
+    const targetUserId = String(formData.get("userId") ?? "").trim();
+    const nextRole = String(formData.get("role") ?? "");
+
+    if (!targetUserId) {
+        redirect(buildMembersPageRedirect(orgId, "error", "Missing member id."));
+    }
+
+    if (!isOrganizationMemberRole(nextRole)) {
+        redirect(buildMembersPageRedirect(orgId, "error", "Invalid role."));
+    }
+
+    // Keeping this simple/safe for PR3: do not let managers accidentally
+    // remove their own management access from the same page.
+    if (targetUserId === currentMembership.user_id) {
+        redirect(
+            buildMembersPageRedirect(
+                orgId,
+                "error",
+                "You cannot change your own role from this page."
+            )
+        );
+    }
+
+    const supabase = await createClient();
+
+    const existingMembershipResult = await supabase
+        .from("org_members")
+        .select("user_id, role")
+        .eq("org_id", orgId)
+        .eq("user_id", targetUserId)
+        .maybeSingle();
+
+    if (existingMembershipResult.error) {
+        throw new Error(existingMembershipResult.error.message);
+    }
+
+    if (existingMembershipResult.data === null) {
+        redirect(
+            buildMembersPageRedirect(
+                orgId,
+                "error",
+                "That member no longer belongs to this organization."
+            )
+        );
+    }
+
+    if (existingMembershipResult.data.role === nextRole) {
+        redirect(
+            buildMembersPageRedirect(
+                orgId,
+                "success",
+                `No change was needed. Role is already ${nextRole.replaceAll("_", " ")}.`
+            )
+        );
+    }
+
+    const updateResult = await supabase
+        .from("org_members")
+        .update({ role: nextRole })
+        .eq("org_id", orgId)
+        .eq("user_id", targetUserId);
+
+    if (updateResult.error) {
+        redirect(
+            buildMembersPageRedirect(
+                orgId,
+                "error",
+                `Failed to update member role: ${updateResult.error.message}`
+            )
+        );
+    }
+
+    revalidatePath(`/organizations/${orgId}/members`);
+    revalidatePath("/organizations");
+
+    redirect(
+        buildMembersPageRedirect(
+            orgId,
+            "success",
+            `Member role updated to ${nextRole.replaceAll("_", " ")}.`
+        )
+    );
+}
+
+// Removes a member from the organization.
+// The removed user loses access on their next request because all protected
+// page loads and actions do a fresh membership lookup.
+export async function removeOrganizationMember(
+  orgId: string,
+  formData: FormData
+) {
+  const currentMembership =
+    await requireOrganizationMemberManagementAccess(orgId);
+
+  const targetUserId = String(formData.get("userId") ?? "").trim();
+
+  if (!targetUserId) {
+    redirect(buildMembersPageRedirect(orgId, "error", "Missing member id."));
+  }
+
+  if (targetUserId === currentMembership.user_id) {
+    redirect(
+      buildMembersPageRedirect(
+        orgId,
+        "error",
+        "You cannot remove yourself from this page."
+      )
+    );
+  }
+
+  const supabase = await createClient();
+
+  const existingMembershipResult = await supabase
+    .from("org_members")
+    .select("user_id")
+    .eq("org_id", orgId)
+    .eq("user_id", targetUserId)
+    .maybeSingle();
+
+  if (existingMembershipResult.error) {
+    throw new Error(existingMembershipResult.error.message);
+  }
+
+  if (existingMembershipResult.data === null) {
+    redirect(
+      buildMembersPageRedirect(
+        orgId,
+        "error",
+        "That member no longer belongs to this organization."
+      )
+    );
+  }
+
+  const deleteResult = await supabase
+    .from("org_members")
+    .delete()
+    .eq("org_id", orgId)
+    .eq("user_id", targetUserId);
+
+  if (deleteResult.error) {
+    throw new Error(deleteResult.error.message);
+  }
+
+  revalidatePath(`/organizations/${orgId}/members`);
+  revalidatePath("/organizations");
+
+  redirect(
+    buildMembersPageRedirect(orgId, "success", "Member removed from organization.")
+  );
+}

--- a/src/app/organizations/[orgId]/members/page.tsx
+++ b/src/app/organizations/[orgId]/members/page.tsx
@@ -6,7 +6,9 @@ import {
 } from "@/lib/organizations";
 import {
   addOrganizationMember,
+  removeOrganizationMember,
   requireOrganizationMemberManagementAccess,
+  updateOrganizationMemberRole,
 } from "./actions";
 
 type MembersPageProps = {
@@ -27,7 +29,8 @@ export default async function OrganizationMembersPage({
   const { error, success } = await searchParams;
 
   // Still protect the page itself, same as PR1.
-  await requireOrganizationMemberManagementAccess(orgId);
+  const currentMembership =
+    await requireOrganizationMemberManagementAccess(orgId);
 
   // Load page data in parallel.
   const [organization, members] = await Promise.all([
@@ -35,8 +38,11 @@ export default async function OrganizationMembersPage({
     getOrganizationMembers(orgId),
   ]);
 
-  // Bind orgId once so the form can just call the action directly.
+  // Bind orgId once so the forms can just call the actions directly.
   const addMemberForOrganization = addOrganizationMember.bind(null, orgId);
+  const updateMemberRoleForOrganization =
+    updateOrganizationMemberRole.bind(null, orgId);
+  const removeMemberFromOrganization = removeOrganizationMember.bind(null, orgId);
 
   return (
     <main className="min-h-screen p-6">
@@ -57,7 +63,6 @@ export default async function OrganizationMembersPage({
           </Link>
         </div>
 
-        {/* Simple success/error feedback after redirects from the server action */}
         {success && (
           <div className="rounded border border-green-500/50 bg-green-500/10 p-3 text-sm text-green-200">
             {success}
@@ -119,8 +124,7 @@ export default async function OrganizationMembersPage({
             <div>
               <h2 className="text-lg font-medium">Current Members</h2>
               <p className="text-sm">
-                Members already in this organization and the role they currently
-                hold.
+                Update roles or remove members from this organization.
               </p>
             </div>
           </div>
@@ -135,13 +139,15 @@ export default async function OrganizationMembersPage({
                     <th className="px-3 py-2 font-medium">Name</th>
                     <th className="px-3 py-2 font-medium">Email</th>
                     <th className="px-3 py-2 font-medium">Role</th>
+                    <th className="px-3 py-2 font-medium">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {members.map((member) => {
-                    // Prefer display name, then email, then fallback text.
                     const displayName = member.user?.display_name?.trim();
                     const email = member.user?.email?.trim();
+                    const isCurrentManager =
+                      member.user_id === currentMembership.user_id;
 
                     return (
                       <tr key={member.user_id} className="border-b last:border-b-0">
@@ -149,8 +155,54 @@ export default async function OrganizationMembersPage({
                           {displayName || email || "Unknown User"}
                         </td>
                         <td className="px-3 py-2">{email || "Unknown Email"}</td>
-                        <td className="px-3 py-2 capitalize">
-                          {member.role.replaceAll("_", " ")}
+                        <td className="px-3 py-2">
+                          <form
+                            action={updateMemberRoleForOrganization}
+                            className="flex min-w-[220px] flex-col gap-2 md:flex-row md:items-center"
+                          >
+                            <input type="hidden" name="userId" value={member.user_id} />
+
+                            <select
+                              name="role"
+                              defaultValue={member.role}
+                              disabled={isCurrentManager}
+                              className="rounded border bg-transparent px-3 py-2"
+                            >
+                              {ORGANIZATION_MEMBER_ROLE_OPTIONS.map((role) => (
+                                <option key={role} value={role}>
+                                  {role.replaceAll("_", " ")}
+                                </option>
+                              ))}
+                            </select>
+
+                            <button
+                              type="submit"
+                              disabled={isCurrentManager}
+                              className="rounded border px-3 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                              Update Role
+                            </button>
+                          </form>
+                        </td>
+                        <td className="px-3 py-2">
+                          <div className="flex flex-col gap-2">
+                            <form action={removeMemberFromOrganization}>
+                              <input type="hidden" name="userId" value={member.user_id} />
+                              <button
+                                type="submit"
+                                disabled={isCurrentManager}
+                                className="rounded border px-3 py-2 disabled:cursor-not-allowed disabled:opacity-50"
+                              >
+                                Remove Member
+                              </button>
+                            </form>
+
+                            {isCurrentManager && (
+                              <p className="text-xs text-gray-400">
+                                Your own role/removal is disabled here.
+                              </p>
+                            )}
+                          </div>
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
requirement: UC3
closes issue: #46 

## What Changed
- added per-member role update controls 
- added member removal controls 
- added server actions for updating roles and removing members
- enforced server-side authorization checks so only admin/treasurer can manage members
- revalidated organization pages after member updates/removals
- improved error handling for failed role updates

## Modules Affected
- `src/app/organizations/[orgId]/members/page.tsx`
- `src/app/organizations/[orgId]/members/actions.ts`

## What Was Tested
- treasurer/admin can open the members management page
- treasurer/admin can change another member’s role
- treasurer can promote a member to admin
- treasurer/admin can remove another member
- removed user loses access on next request/refresh
- unauthorized users are denied access

## How to Test
1. Sign in as a treasurer or admin.
2. Go to `/organizations`, then open an organization’s members page.
3. Change a member’s role and click `Update Role`.
4. Confirm the success message appears and the new role shows in the table.
5. Remove a different member and confirm they disappear from the member list.
6. Sign in as the removed user or refresh their existing session.
7. Confirm they lose access to that organization on the next request.
8. Sign in as a non-manager and try to access the members page.
9. Confirm access is denied.