### PR TITLE
UC 9 Export CSV More Error Checking PR3

### DIFF
--- a/src/app/csv/action.ts
+++ b/src/app/csv/action.ts
@@ -2,33 +2,61 @@
 
 import { createClient } from "@/lib/supabase/server";
 
-export async function exportCSV() {
+//Grabbing membership info
+export async function getOrgMemberships() {
     const supabase = await createClient();
 
-    const {data: { user }, error: authError} = await supabase.auth.getUser();
-    if (authError || !user) {
-        return { error: "Unauthorized" };
-    }
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) return { error: "Unauthorized", code: "unauthorized" };
 
-    const {data: org_members, error: orgError} = await supabase
+    const { data: memberships, error: memberError } = await supabase
         .from("org_members")
-        .select("org_id")
+        .select("org_id, role, organizations(org_name)")
         .eq("user_id", user.id)
+        .in("role", ["treasurer", "advisor"]);
+
+    if (memberError) return { error: memberError.message, code: "db_error" };
+    if (!memberships || memberships.length === 0) return { error: "You are not a treasurer or advisor of any organization.", code: "no_org" };
+
+    return { memberships };
+}
+
+//Grabbing transaction data to export as csv file
+export async function exportCSV(orgId: string) {
+    const supabase = await createClient();
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) return { error: "Unauthorized", code: "unauthorized" };
+
+    const { data: member, error: memberError } = await supabase
+        .from("org_members")
+        .select("role")
+        .eq("user_id", user.id)
+        .eq("org_id", orgId)
+        .in("role", ["treasurer", "advisor"])
         .single();
 
-    if(orgError || !org_members) {
-        return { error: "Organization not found" };
-    }
+    if (memberError || !member) return {
+        error: "You do not have permission to export transactions for this organization.",
+        code: "no_permission"
+    };
+
+    const { data: org } = await supabase
+        .from("organizations")
+        .select("org_name")
+        .eq("org_id", orgId)
+        .single();
 
     const { data, error } = await supabase
         .from("transactions")
-        .select("*")
-        .eq("org_id", org_members.org_id);
-    if (error) {
-        return { error: "Failed to fetch transactions" };
-    }
+        .select("*, date")
+        .eq("org_id", orgId)
+        .order("date", { ascending: false });
 
-    return { data };
+    if (error) return { error: error.message, code: "db_error" };
+    if (!data || data.length === 0) return { error: "No transactions found to export.", code: "no_data" };
+
+    return { data, orgName: org?.org_name ?? orgId };
 }
 
 

--- a/src/app/csv/page.tsx
+++ b/src/app/csv/page.tsx
@@ -1,45 +1,151 @@
 "use client";
 
-import { useState } from "react";
-import { exportCSV } from "./action";
+import { useState, useEffect } from "react";
+import { getOrgMemberships, exportCSV } from "./action";
 
-export default function CSVPage( ) {
-    const [error, setError] = useState<string | null>(null);
-    
-    const handleExport = async () => {
-        setError(null);
-        const result = await exportCSV();
-
-        if ('error' in result) {
-            setError(result.error ?? "An error occurred during export.");
-            return;
-    }
-
-    const data = result.data;
-    if (!data || data.length === 0) {
-        setError("No transactions found to export.");
-        return;
-    }
-
-    const headers = Object.keys(data[0]).join(",");
-    const rows = data.map(row => Object.values(row).join(",")).join("\n");
-    const csv = `${headers}\n${rows}`;
-
-    const blob = new Blob([csv], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "transactions.csv";
-    a.click();
-    URL.revokeObjectURL(url);
+//Storing membership information
+type Membership = {
+    org_id: string;
+    role: string;
+    organizations: { org_name: string } | { org_name: string }[] | null;
 };
 
+//exporting csv file
+export default function CSVPage( ) {
+    const [memberships, setMemberships] = useState<Membership[]>([]);
+    const [selectedOrgId, setSelectedOrgId] = useState<string>("");
+    const [fetchError, setFetchError] = useState<string | null>(null);
+    const [permissionError, setPermissionError] = useState<string | null>(null);
+    const [exportError, setExportError] = useState<string | null>(null);
+    const [noOrg, setNoOrg] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchMemberships = async () => {
+            const result = await getOrgMemberships();
+            if ('error' in result) {
+                if (result.code === "no_org") {
+                    setNoOrg(true);
+                } else {
+                    setFetchError(result.error ?? "An error occurred while fetching memberships.");
+                }
+            } else {
+                setMemberships(result.memberships as Membership[]);
+                if (result.memberships.length === 1) {
+                    setSelectedOrgId(result.memberships[0].org_id);
+                }
+            }
+            setLoading(false);
+        };
+        fetchMemberships();
+    }, []);
+    
+    const handleExport = async () => {
+        setPermissionError(null);
+        setExportError(null);
+
+         const result = await exportCSV(selectedOrgId);
+        if ('error' in result) {
+            if (result.code === "no_permission") {
+                setPermissionError(result.error ?? "You do not have permission to export.");
+            } else {
+                setExportError(result.error ?? "An error occurred during export.");
+            }
+            return;
+        }
+
+        const { data, orgName } = result;
+        const safeName = orgName.replace(/[^a-z0-9]/gi, "_").toLowerCase();
+
+        const escapeCell = (value: unknown): string => {
+            if (value === null || value === undefined) return "";
+            const str = String(value);
+            if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+                return `"${str.replace(/"/g, '""')}"`;
+            }
+            return str;
+        };
+
+    //exporting file to csv format
+    const headers = Object.keys(data[0]).map(escapeCell).join(",");
+        const rows = data.map(row =>
+            Object.values(row).map(escapeCell).join(",")
+        ).join("\n");
+        const csv = `${headers}\n${rows}`;
+
+        const blob = new Blob(["\uFEFF" + csv], { type: "text/csv;charset=utf-8;" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${safeName}_transactions.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    if (loading) return <p className="p-4">Loading...</p>;
+
+        //If user is not a treasurer or advisor of any organization, show message
+        if (noOrg) return (
+            <div className="p-4 space-y-2">
+                <h1 className="text-xl font-semibold">Exporting Transactions into CSV File</h1>
+                <div className="bg-yellow-50 border border-yellow-300 text-yellow-800 px-4 py-3 rounded">
+                    <p className="font-medium">No organization found</p>
+                    <p className="text-sm">You must be a treasurer or advisor of an organization to export transactions.</p>
+                </div>
+            </div>
+        );
+
+    //Page output
     return (
-        <div>
-            <h1>Exporting Transactions into CSV File</h1>
-            {error && <p className="text-red-500">{error}</p>}
-            <button onClick={() => handleExport()}
-                 className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 active:scale-95 transition-all">
+        <div className="p-4 space-y-4">
+            <h1 className="text-xl font-semibold">Exporting Transactions into CSV File</h1>
+
+            {fetchError && (
+                <div className="bg-red-50 border border-red-300 text-red-700 px-4 py-3 rounded">
+                    <p className="font-medium">Failed to load organizations</p>
+                    <p className="text-sm">{fetchError}</p>
+                </div>
+            )}
+
+            {permissionError && (
+                <div className="bg-orange-50 border border-orange-300 text-orange-700 px-4 py-3 rounded">
+                    <p className="font-medium">Permission Denied</p>
+                    <p className="text-sm">{permissionError}</p>
+                </div>
+            )}
+
+            {exportError && (
+                <div className="bg-red-50 border border-red-300 text-red-700 px-4 py-3 rounded">
+                    <p className="font-medium">Export Failed</p>
+                    <p className="text-sm">{exportError}</p>
+                </div>
+            )}
+
+            {memberships.length > 1 && (
+                <div>
+                    <label className="block text-sm font-medium mb-1">Select Organization</label>
+                    <select
+                        value={selectedOrgId}
+                        onChange={(e) => setSelectedOrgId(e.target.value)}
+                        className="border rounded px-3 py-2 w-64"
+                    >
+                        <option value="" disabled>Select an organization...</option>
+                        {memberships.map((m) => {
+                            const orgName = Array.isArray(m.organizations)
+                                ? m.organizations[0]?.org_name
+                                : m.organizations?.org_name;
+                            return (
+                                <option key={m.org_id} value={m.org_id}>
+                                    {orgName ?? m.org_id}
+                                </option>
+                            );
+                        })}
+                    </select>
+                </div>
+            )}
+            <button onClick={handleExport}
+                disabled={!selectedOrgId}
+                className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 active:scale-95 transition-all">
                 Export Transactions
             </button>
         </div>


### PR DESCRIPTION
## Description
<!-- One sentence description -->
Added role base errors, multiple org exceptions, and changed file name.
---

## Changes
- Added role base errors, so only treasurers or advisors can export transactions
- Added dropdown menu for users in multiple organizations
- Changed file name to include the organization name

---

## How to Test
1.  Use "npm run dev" in terminal
2.  Login with any user 
3.  Go to http:localhost3000/csv
4.  Verify that treasurers/advisors of one org that has transactions can export file
5.  Verify that anyone that isn't a treasurer/advisor cannot export
6.  Verify that anyone no in an organization cannot export
7.  Verify that anyone that is treasurer/advisor in multiple clubs has a dropdown menu
8.  Verify that anyone that is a treasure/advisor of a club that has no transactions receives an error message

---

## Screenshots
<!-- Only if you changed the UI - drag and drop images here -->
<img width="523" height="322" alt="image" src="https://github.com/user-attachments/assets/b7f57ddc-e5e7-4b6d-aa4e-06c9bcd1f26a" />
<img width="484" height="231" alt="Screenshot 2026-03-29 113804" src="https://github.com/user-attachments/assets/8696edf4-33bf-4d6d-aea8-31eb996b8c1e" />
<img width="675" height="168" alt="Screenshot 2026-03-29 113000" src="https://github.com/user-attachments/assets/44d69474-eece-40d8-91fe-4980f7723237" />
<img width="370" height="221" alt="Screenshot 2026-03-29 090648" src="https://github.com/user-attachments/assets/a6a26a74-437f-4124-88ac-3bfc49ad6657" />

---

## Checklist
<!-- Mark with an X -->
- [ X ] Tested locally
- [ X ] No errors in console

## Notes
Closes #6 

Claude AI helped with implementation and error handling: https://claude.ai/share/a376abc6-6106-4d66-90c2-7210f1c31ed9