### PR TITLE
Org Dropdown Search Feature

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,7 @@ type NavbarProps = {
   currentUserRole: string;
   basePath: string;
   pageTitle: string;
-  logoSrc?: string  | null;
+  logoSrc?: string | null;
   logoAlt?: string;
 };
 
@@ -41,6 +41,7 @@ export default function Navbar({
         bg-black/80
         px-5 py-4
         backdrop-blur-md
+        relative z-[9999]
       "
     >
       <div className="mx-auto flex max-w-7xl flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -1,67 +1,128 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useState, useRef, useEffect } from 'react'
 
 type Props = {
-    organizations: {
-        org_id: string
-        org_name: string
-        role: string
-    }[]
-    currentOrgId: string
-    basePath: string // e.g. '/dashboard' or '/files'
+  organizations: {
+    org_id: string
+    org_name: string
+    role: string
+  }[]
+  currentOrgId: string
+  basePath: string
 }
 
 export default function OrgDropDown({ organizations, currentOrgId, basePath }: Props) {
-    const router = useRouter();
-    return (
-        <div>
-      <label htmlFor="org-select" className="sr-only">
-        Change Organization
-      </label>
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
-      <select
-        id="org-select"
-        defaultValue=""
-        onChange={(e) => {
-          const selectedOrgId = e.target.value
-          if (!selectedOrgId) return
-          const path = basePath === "/" ? "" : basePath;
-          e.target.value = "" // reset to "Change Org"
-          router.push(`${basePath}?orgId=${selectedOrgId}`)
-        }}
+  const otherOrgs = organizations.filter((org) => org.org_id !== currentOrgId)
+
+  const filtered = query.trim()
+    ? otherOrgs.filter((org) =>
+      org.org_name.toLowerCase().includes(query.toLowerCase())
+    )
+    : otherOrgs
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+        setQuery('')
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  const handleSelect = (orgId: string) => {
+    setOpen(false)
+    setQuery('')
+    router.push(`${basePath}?orgId=${orgId}`)
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
         className="
           font-[var(--font-geist-sans)]
-          cursor-pointer
-          rounded-lg
+          cursor-pointer rounded-lg
           border border-white/[0.15]
-          bg-white/[0.04]
+          bg-blue-600
           px-3 py-1.5
-          pr-3
           text-xs font-medium tracking-wide text-neutral-200
           transition
-          hover:border-white/[0.3]
-          hover:bg-white/[0.07]
+          hover:border-white/[0.3] hover:bg-white/[0.07]
           focus:outline-none
         "
       >
-        {/* Placeholder */}
-        <option value="" disabled className="bg-black text-neutral-400">
-          CHANGE ORGANIZATION
-        </option>
-        {/* Other orgs */}
-        {organizations
-          .filter((org) => org.org_id !== currentOrgId)
-          .map((org) => (
-            <option
-              key={org.org_id}
-              value={org.org_id}
-              className="bg-black text-white"
-            >
-              {org.org_name}
-            </option>
-          ))}
-      </select>
+        CHANGE ORGANIZATION
+      </button>
+
+      {open && (
+        <div className="
+          absolute left-0 top-full z-50 mt-1 w-56
+          rounded-lg border border-white/[0.15]
+          bg-neutral-950 shadow-xl
+        ">
+          {/* Search input */}
+          <div className="border-b border-white/[0.1] p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && filtered.length > 0) {
+                  handleSelect(filtered[0].org_id)
+                }
+              }}
+              placeholder="Search organizations..."
+              className="
+                w-full rounded-md
+                bg-white/[0.06]
+                px-2 py-1.5
+                text-xs text-neutral-200 placeholder-neutral-500
+                focus:outline-none focus:ring-1 focus:ring-white/20
+              "
+            />
+          </div>
+
+          {/* Options */}
+          <ul className="max-h-52 overflow-y-auto py-1">
+            {filtered.length > 0 ? (
+              filtered.map((org) => (
+                <li key={org.org_id}>
+                  <button
+                    onClick={() => handleSelect(org.org_id)}
+                    className="
+                      w-full px-3 py-2 text-left
+                      text-xs text-neutral-200
+                      hover:bg-white/[0.08]
+                      transition-colors
+                    "
+                  >
+                    {org.org_name}
+                  </button>
+                </li>
+              ))
+            ) : (
+              <li className="px-3 py-2 text-xs text-neutral-500">No results</li>
+            )}
+          </ul>
+        </div>
+      )}
     </div>
-    )
+  )
 }


### PR DESCRIPTION
## Description
<!-- One sentence description -->
Added color to dropdown button and search feature
Closes #77 
---

## Changes
- drop down button is now blue to make it obvious that it is something to click
- there is a search feature for those in a lot of orgs

---

## How to Test
1. npm run dev
2. sign in with a user in multiple orgs
3. click through the drop down to make sure it works (dashboard, files, audit log)
4. use the search feature by inputting an org name and pressing enter or clicking on the org

---

## Screenshots
<!-- Only if you changed the UI - drag and drop images here -->
<img width="425" height="370" alt="image" src="https://github.com/user-attachments/assets/18a275a9-a2e7-4ebd-ac8d-4e7363268081" />

---

## Checklist
<!-- Mark with an X -->
- [ X ] Tested locally
- [ X ] No errors in console

##Notes
Consulting with Claude AI to implement the search feature and solve some bugs. I ran into an issue with the dashboard where the titles were blurred, so I had to take it out.
https://claude.ai/share/baf42542-2d6c-43fa-b441-956903b3a230