### PR TITLE
[feat] Add password reset flow

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,22 +1,31 @@
-// Handles the OAuth/email confirmation callback from Supabase
-// Exchanges the temporary auth code for a session
-import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/server"
+import { NextResponse, type NextRequest } from "next/server"
 
-export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
-  const code = searchParams.get("code");
+// Handles the redirect from Supabase auth emails (signup confirmation,
+// password recovery, magic links). The link in the email contains a `code`
+// query param; we exchange that code for a session, then redirect the user
+// to wherever the `next` param says (or home).
+//
+// Used by:
+//   - UC1 email confirmation (?next=/)
+//   - Password reset (?next=/reset-password)
+export async function GET(request: NextRequest) {
+    const { searchParams, origin } = new URL(request.url)
+    const code = searchParams.get("code")
+    const next = searchParams.get("next") ?? "/"
 
-  if (code) {
-    const supabase = await createClient();
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-
-    if (!error) {
-      // Auth successful, send user to the main app
-      return NextResponse.redirect(`${origin}/`);
+    if (!code) {
+        // No code = bad link. Send them to login with a generic error
+        // rather than leaking what specifically went wrong.
+        return NextResponse.redirect(`${origin}/login?error=invalid_link`)
     }
-  }
 
-  // Auth failed, send back to login with error indicator
-  return NextResponse.redirect(`${origin}/login?error=auth`);
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (error) {
+        return NextResponse.redirect(`${origin}/login?error=invalid_link`)
+    }
+
+    return NextResponse.redirect(`${origin}${next}`)
 }

--- a/src/app/forgot-password/actions.ts
+++ b/src/app/forgot-password/actions.ts
@@ -1,0 +1,33 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { isValidEmail } from "@/lib/authValidation"
+
+// Server action: triggers Supabase to send a password reset email.
+// The link in that email points back to /auth/callback?type=recovery
+// which then redirects the user to /reset-password where they set a new one.
+export async function requestPasswordReset(email: string) {
+    if (!isValidEmail(email)) {
+        return { error: "Invalid email format" }
+    }
+
+    const supabase = await createClient()
+
+    // The redirectTo URL must be added to Supabase Dashboard
+    // → Authentication → URL Configuration → Redirect URLs
+    // We read the site URL from env so it works in dev and prod.
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email.trim().toLowerCase(), {
+        redirectTo: `${siteUrl}/auth/callback?next=/reset-password`,
+    })
+
+    if (error) {
+        // Don't surface the underlying error to the client
+        // since it could leak whether the email exists.
+        // Page-level UI shows a generic success message either way.
+        return { error: error.message }
+    }
+
+    return { ok: true }
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useState } from "react"
+import { requestPasswordReset } from "./actions"
+import BackButton from "@/components/BackButton"
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("")
+    const [error, setError] = useState("")
+    const [success, setSuccess] = useState(false)
+    const [loading, setLoading] = useState(false)
+
+    async function handleSubmit() {
+        setError("")
+
+        if (!email.trim()) {
+            setError("Please enter an email")
+            return
+        }
+
+        setLoading(true)
+        const result = await requestPasswordReset(email)
+        setLoading(false)
+
+        if (result?.error) {
+            // We still show success even on most errors to avoid leaking
+            // whether the email exists in our system (per UC1 validation rules)
+            setSuccess(true)
+            return
+        }
+
+        setSuccess(true)
+    }
+
+    if (success) {
+        return (
+            <div className="mt-10 flex flex-col items-center gap-4">
+                <p className="text-green-500 text-center max-w-md">
+                    If that email is registered, a password reset link has been sent.
+                    Check your inbox.
+                </p>
+                <BackButton label="Back to Login" />
+            </div>
+        )
+    }
+
+    return (
+        <div>
+            <div className="mt-5 flex flex-col items-center justify-center gap-3">
+                <h1 className="text-xl font-semibold mb-2">Reset your password</h1>
+                <p className="text-sm text-neutral-400 max-w-sm text-center mb-2">
+                    Enter your account email and we&apos;ll send you a link to reset your password.
+                </p>
+
+                <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
+                    placeholder="Email"
+                />
+
+                <div className="flex gap-2">
+                    <button
+                        onClick={handleSubmit}
+                        disabled={loading}
+                        className="border border-gray-300 rounded p-2 text-gray-900 hover:bg-gray-100 disabled:opacity-50 dark:border-white/[0.2] dark:text-white dark:hover:bg-white/[0.1]"
+                    >
+                        {loading ? "Sending..." : "Send reset link"}
+                    </button>
+                    <BackButton label="Cancel" />
+                </div>
+
+                {error && <p className="text-red-500 text-sm">{error}</p>}
+            </div>
+        </div>
+    )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -34,10 +34,10 @@ export default function LoginPage() {
     }
 
     return(
-     
+
         <div>
             <div className="mt-5 flex items-center justify-center mb-3 gap-2">
-            <input 
+            <input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -45,29 +45,32 @@ export default function LoginPage() {
                 placeholder="Email"
                 />
 
-            <input 
+            <input
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="border border-gray-300 rounded p-2 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white" //changed to make it visible for light mode - prabh
                 placeholder="Password"
             />
-             
+
             <button onClick={handleSubmit} className="border border-gray-300 rounded p-2 text-gray-900 hover:bg-gray-100 dark:border-white/[0.2] dark:text-white dark:hover:bg-white/[0.1]" //changed to make it visible for light mode - prabh
-            > 
+            >
                 Login
             </button>
             </div>
-            <div className="flex items-center justify-center mb-3 mt-5">
+            <div className="flex flex-col items-center justify-center mb-3 mt-5 gap-2">
                 <a href="/register" className="text-sm text-blue-500 hover:underline">
                     Don&apos;t have an account? Register
+                </a>
+                <a href="/forgot-password" className="text-sm text-blue-500 hover:underline">
+                    Forgot your password?
                 </a>
             </div>
             <div className="flex items-center justify-center mb-3">
              {error && <p className="text-red-500">{error}</p>}
             </div>
         </div>
-        
+
     );
-    
+
 }

--- a/src/app/reset-password/actions.ts
+++ b/src/app/reset-password/actions.ts
@@ -1,0 +1,36 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { isValidPassword } from "@/lib/authValidation"
+
+// Server action: updates the password for the currently-authenticated user.
+// At this point the user has clicked the recovery link in their email,
+// so they have a temporary recovery session. We update the password and
+// then sign them out so they have to log in fresh.
+export async function updatePassword(newPassword: string) {
+    if (!isValidPassword(newPassword)) {
+        return { error: "Password must be at least 8 characters" }
+    }
+
+    const supabase = await createClient()
+
+    // Confirm there's an active session before trying to update.
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+        return { error: "No active reset session. Please request a new reset link." }
+    }
+
+    const { error: updateError } = await supabase.auth.updateUser({
+        password: newPassword,
+    })
+
+    if (updateError) {
+        return { error: updateError.message }
+    }
+
+    // Sign the user out so they have to log in with the new password.
+    // Otherwise the recovery session would let them stay in indefinitely.
+    await supabase.auth.signOut()
+
+    return { ok: true }
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { updatePassword } from "./actions"
+import { isValidPassword } from "@/lib/authValidation"
+
+export default function ResetPasswordPage() {
+    const router = useRouter()
+    const [password, setPassword] = useState("")
+    const [confirmPassword, setConfirmPassword] = useState("")
+    const [error, setError] = useState("")
+    const [loading, setLoading] = useState(false)
+
+    async function handleSubmit() {
+        setError("")
+
+        if (!isValidPassword(password)) {
+            setError("Password must be at least 8 characters")
+            return
+        }
+
+        if (password !== confirmPassword) {
+            setError("Passwords do not match")
+            return
+        }
+
+        setLoading(true)
+        const result = await updatePassword(password)
+        setLoading(false)
+
+        if (result?.error) {
+            setError(result.error)
+            return
+        }
+
+        // Password updated. Sign-out happens server-side so the user
+        // logs in fresh with the new password.
+        router.push("/login")
+    }
+
+    return (
+        <div>
+            <div className="mt-5 flex flex-col items-center justify-center gap-3">
+                <h1 className="text-xl font-semibold mb-2">Set a new password</h1>
+                <p className="text-sm text-neutral-400 max-w-sm text-center mb-2">
+                    Choose a new password for your account. You&apos;ll be redirected to login after.
+                </p>
+
+                <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
+                    placeholder="New password"
+                />
+
+                <input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
+                    placeholder="Confirm new password"
+                />
+
+                <button
+                    onClick={handleSubmit}
+                    disabled={loading}
+                    className="border border-gray-300 rounded p-2 text-gray-900 hover:bg-gray-100 disabled:opacity-50 dark:border-white/[0.2] dark:text-white dark:hover:bg-white/[0.1]"
+                >
+                    {loading ? "Updating..." : "Update password"}
+                </button>
+
+                {error && <p className="text-red-500 text-sm">{error}</p>}
+            </div>
+        </div>
+    )
+}

--- a/src/lib/authValidation.ts
+++ b/src/lib/authValidation.ts
@@ -1,0 +1,20 @@
+// Shared validation helpers for auth-related forms.
+// Used by login, register, forgot-password, and reset-password.
+
+// Minimum password length per UC1 ("password must meet certain minimum requirements").
+// Supabase Auth's default minimum is 6, we're slightly stricter at 8.
+export const MIN_PASSWORD_LENGTH = 8
+
+// RFC 5322 is overkill for our use case. This catches the common typos
+// (missing @, missing TLD, spaces) without being a regex maze.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function isValidEmail(email: string): boolean {
+    if (!email) return false
+    return EMAIL_PATTERN.test(email.trim())
+}
+
+export function isValidPassword(password: string): boolean {
+    if (!password) return false
+    return password.length >= MIN_PASSWORD_LENGTH
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,16 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
+// Paths that an unauthenticated user is allowed to hit.
+// Anything not in this list will bounce them to /login.
+const PUBLIC_PATHS = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/auth/callback",
+];
+
 export async function middleware(request: NextRequest) {
   // Start with a default "continue" response (let the request through)
   let supabaseResponse = NextResponse.next({
@@ -39,22 +49,21 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // If no user AND the path is not /login or /register,
-  //   redirect to /login
-  if(user === null) {
-    if(request.nextUrl.pathname !== "/login" && request.nextUrl.pathname !== "/register") {
-        return NextResponse.redirect(new URL("/login", request.url));
-    }
+  const pathname = request.nextUrl.pathname;
+  const isPublicPath = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+
+  // Unauthenticated user trying to hit a protected route -> redirect to /login
+  if (user === null && !isPublicPath) {
+    return NextResponse.redirect(new URL("/login", request.url));
   }
 
-  // If user exists AND the path is /login or /register,
-  //   redirect to /
-  if(user !== null) {
-    if(request.nextUrl.pathname === "/login" || request.nextUrl.pathname === "/register") {
-        return NextResponse.redirect(new URL("/", request.url));
-    }
+  // Authenticated user trying to hit /login or /register -> bounce to /
+  // Note: /forgot-password and /reset-password are intentionally NOT bounced.
+  // A logged-in user who clicks a stale recovery link should still be able
+  // to land on /reset-password and complete the flow.
+  if (user !== null && (pathname === "/login" || pathname === "/register")) {
+    return NextResponse.redirect(new URL("/", request.url));
   }
-
 
   return supabaseResponse;
 }

--- a/src/tests/authValidation.test.ts
+++ b/src/tests/authValidation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import { isValidEmail, isValidPassword, MIN_PASSWORD_LENGTH } from "../lib/authValidation"
+
+// ─────────────────────────────────────────────
+// isValidEmail
+// ─────────────────────────────────────────────
+describe("isValidEmail", () => {
+    it("accepts a normal email", () => {
+        expect(isValidEmail("test@example.com")).toBe(true)
+    })
+
+    it("accepts an email with a subdomain", () => {
+        expect(isValidEmail("user@mail.unlv.edu")).toBe(true)
+    })
+
+    it("accepts an email with a plus tag", () => {
+        expect(isValidEmail("user+tag@example.com")).toBe(true)
+    })
+
+    it("rejects an empty string", () => {
+        expect(isValidEmail("")).toBe(false)
+    })
+
+    it("rejects a string with no @ sign", () => {
+        expect(isValidEmail("notanemail.com")).toBe(false)
+    })
+
+    it("rejects a string with no domain", () => {
+        expect(isValidEmail("user@")).toBe(false)
+    })
+
+    it("rejects a string with no TLD", () => {
+        expect(isValidEmail("user@example")).toBe(false)
+    })
+
+    it("rejects an email with spaces", () => {
+        expect(isValidEmail("user @example.com")).toBe(false)
+    })
+
+    it("trims surrounding whitespace before validating", () => {
+        expect(isValidEmail("  test@example.com  ")).toBe(true)
+    })
+})
+
+// ─────────────────────────────────────────────
+// isValidPassword
+// ─────────────────────────────────────────────
+describe("isValidPassword", () => {
+    it("accepts a password meeting the minimum length", () => {
+        expect(isValidPassword("a".repeat(MIN_PASSWORD_LENGTH))).toBe(true)
+    })
+
+    it("accepts a long password", () => {
+        expect(isValidPassword("a-very-long-password-1234")).toBe(true)
+    })
+
+    it("rejects a password shorter than the minimum", () => {
+        expect(isValidPassword("a".repeat(MIN_PASSWORD_LENGTH - 1))).toBe(false)
+    })
+
+    it("rejects an empty password", () => {
+        expect(isValidPassword("")).toBe(false)
+    })
+
+    it("documents the current minimum length", () => {
+        // If we ever bump the minimum, this test pin makes the change explicit
+        expect(MIN_PASSWORD_LENGTH).toBe(8)
+    })
+})


### PR DESCRIPTION
## Description
Adds a complete password reset flow (request email -> click link -> set new password) plus the auth callback route needed to exchange Supabase email codes for sessions. Closes #66.

---

## Changes
- Added `src/app/forgot-password/page.tsx` + `actions.ts` for requesting a reset email
- Added `src/app/reset-password/page.tsx` + `actions.ts` for setting a new password
- Implemented `src/app/auth/callback/route.ts` (was empty); exchanges the email code for a session and redirects to `next` query param
- Added `src/lib/authValidation.ts` with shared `isValidEmail` / `isValidPassword` helpers
- Updated `src/middleware.ts` to allow `/forgot-password`, `/reset-password`, `/auth/callback` for unauthenticated users
- Added "Forgot your password?" link to the login page
- Added unit tests in `src/tests/authValidation.test.ts`

---

## How to Test

**Setup**
The Supabase project's Site URL is already configured to allow localhost:3000 callbacks, so no dashboard changes should be needed for local testing. If for some reason the reset email link returns an invalid_link error, the project owner (Danilo) may need to add http://localhost:3000/auth/callback to Authentication → URL Configuration → Redirect URLs.

**Test the flow:**
1. Run the dev server (`npm run dev`)
2. Go to `/login`, click "Forgot your password?"
3. Enter the email of a registered account, click "Send reset link"
4. Confirmation message appears regardless of whether email is registered (intentional, no enumeration)
5. Check the inbox for that email; click the reset link
6. You should land on `/reset-password` with an active session
7. Enter a new password (8+ chars), confirm it, click "Update password"
8. You should be redirected to `/login`
9. Log in with the new password to confirm it works

**Test invalid cases:**
- Visit `/forgot-password` with empty email -> "Please enter an email"
- On `/reset-password` with mismatched fields -> "Passwords do not match"
- On `/reset-password` with password under 8 chars -> "Password must be at least 8 characters"
- Visit `/auth/callback` directly (no code) -> redirected to `/login?error=invalid_link`

**Run the tests:**
```bash
npm test -- authValidation
```

---

## Screenshots
<!-- Add screenshots of /forgot-password, the success state, and /reset-password -->
<img width="2091" height="420" alt="image" src="https://github.com/user-attachments/assets/38daf4d2-a473-4e10-853e-aed975eccf48" />
<img width="1939" height="553" alt="image" src="https://github.com/user-attachments/assets/12848144-1446-41d8-9890-3701891e9bb4" />
<img width="1947" height="571" alt="image" src="https://github.com/user-attachments/assets/df45f1e4-ef58-4276-8012-f2a86161e0ff" />
<img width="1951" height="590" alt="image" src="https://github.com/user-attachments/assets/bbf96da9-663f-425d-be52-d070505bf88e" />
<img width="2645" height="840" alt="image" src="https://github.com/user-attachments/assets/33cbcedc-bad2-45d8-9982-2007f0226421" />
<img width="2095" height="734" alt="image" src="https://github.com/user-attachments/assets/db6c27db-e27a-492e-b39f-c600b0e45a0f" />

---

## Checklist
- [x] Tested locally
- [x] No errors in console
- [x] Unit tests added for new validation helpers
- [x] Middleware updated to allow new public routes
- [x] PR description includes Supabase dashboard setup step