### PR TITLE
Added organization scoping to transactions pages

### DIFF
--- a/src/app/transaction/[id]/edit/page.tsx
+++ b/src/app/transaction/[id]/edit/page.tsx
@@ -1,19 +1,28 @@
-import { fetchTransactionFromId } from "@/app/transaction/lib/data";
+import { fetchOrgsOptionsFromCurrentUser, fetchTransactionFromId } from "@/app/transaction/lib/data";
 import { UpdateTransactionForm } from "../../ui/form";
-import { type Transaction } from "../../lib/actions";
 
 export const metadata = { title: "Edit Transaction" };
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ orgId?: string }>
 }) {
   const { id } = await params;
+  const resolvedSearch = await searchParams;
+  const organizations = await fetchOrgsOptionsFromCurrentUser();
+  const orgId = resolvedSearch?.orgId ?? (() => {
+    const fallback = organizations[0].org_id;
+    console.log("No searchParam 'orgId' found. \nFalling back to: ", fallback)
+    return fallback;
+  })();
   const transaction = await fetchTransactionFromId(id);
+
   return (
     <main>
-      <UpdateTransactionForm transaction={transaction} />
+      <UpdateTransactionForm transaction={transaction} orgId={orgId} />
     </main>
   );
 }

--- a/src/app/transaction/create/page.tsx
+++ b/src/app/transaction/create/page.tsx
@@ -1,11 +1,24 @@
 import { CreateTransactionForm } from "@/app/transaction/ui/form";
+import { fetchOrgsOptionsFromCurrentUser } from "../lib/data";
 
 export const metadata = { title: "New Transaction" };
 
-export default function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ orgId?: string }>
+}) {
+  const params = await searchParams;
+  const organizations = await fetchOrgsOptionsFromCurrentUser();
+  const orgId = params?.orgId ?? (() => {
+    const fallback = organizations[0].org_id;
+    console.log("No searchParam 'orgId' found. \nFalling back to: ", fallback)
+    return fallback;
+  })();
+
   return (
     <main>
-      <CreateTransactionForm />
+      <CreateTransactionForm orgId={orgId} />
     </main>
   );
 }

--- a/src/app/transaction/lib/actions.ts
+++ b/src/app/transaction/lib/actions.ts
@@ -7,27 +7,17 @@ import { fetchOrgFromCurrentUser, fetchUserId } from "@/app/transaction/lib/data
 import { z } from "zod";
 import { logAuditEntry } from "@/app/audit/lib/action";
 import { AuditLogType } from "@/app/audit/lib/data";
+import { TransactionsSchema, type ActionState } from "@/app/transaction/lib/schemas";
 
-const TransactionSchema = z.object({
-  transaction_id: z.uuid(),
-  orgId: z.uuid(),
-  date: z.coerce.date().max(new Date(), "Date cannot be in future"),
-  description: z.string().nonempty("Please add description"),
-  category: z.string().nonempty("Please add category"),
-  type: z.enum(["income", "expense"]),
-  amount: z.coerce.number().positive("Amount must be greater than $0.00"),
-  notes: z.string().optional()
-})
+const CreateTransactionSchema = TransactionsSchema.omit({ transaction_id: true })
 
-const CreateTransactionSchema = TransactionSchema.omit({ transaction_id: true })
-
-export async function createTransaction(_prevState: any, formData: FormData) {
+export async function createTransaction(_prevState: ActionState, formData: FormData) : Promise<ActionState> {
   const supabase = await createClient();
-  const fetchOrgId = await fetchOrgFromCurrentUser();
+  const fetchOrgId = await fetchOrgFromCurrentUser(); // TODO: Replace
   const userId = await fetchUserId();
 
   const result = CreateTransactionSchema.safeParse({
-    orgId: fetchOrgId,
+    org_id: fetchOrgId,
     type: formData.get("type"),
     description: formData.get("desc"),
     category: formData.get("category"),
@@ -42,7 +32,7 @@ export async function createTransaction(_prevState: any, formData: FormData) {
     };
   }
 
-  const { orgId, type, description, category, amount, date, notes } = result.data;
+  const { org_id, type, description, category, amount, date, notes } = result.data;
 
   // Insert to database
   // I updated the insertion statement to return the inserted row
@@ -50,8 +40,8 @@ export async function createTransaction(_prevState: any, formData: FormData) {
   const { data, error } = await supabase
     .from('transactions')
     .insert({
-      org_id: orgId, created_by: userId, date: date, description: description, category: category,
-      type: type, amount: amount, notes: notes
+      org_id, created_by: userId, date, description, category,
+      type, amount, notes
     })
     .select()
     .single();
@@ -80,7 +70,7 @@ export async function createTransaction(_prevState: any, formData: FormData) {
 
   // Insert audit log entry for transaction creation
   await logAuditEntry({
-    orgId: orgId,
+    orgId: org_id,
     userId: userId,
     action: "CREATE",
     entity_type: "transaction",
@@ -98,11 +88,11 @@ export async function createTransaction(_prevState: any, formData: FormData) {
   redirect('/transaction')
 }
 
-export async function updateTransaction(_prevState: any, formData: FormData) {
+export async function updateTransaction(_prevState: ActionState, formData: FormData) : Promise<ActionState> {
   const supabase = await createClient();
-  const fetchOrgId = await fetchOrgFromCurrentUser();
+  const fetchOrgId = await fetchOrgFromCurrentUser(); // TODO: Replace
 
-  const result = TransactionSchema.safeParse({
+  const result = TransactionsSchema.safeParse({
     transaction_id: formData.get("transId"),
     orgId: fetchOrgId,
     type: formData.get("type"),
@@ -122,7 +112,7 @@ export async function updateTransaction(_prevState: any, formData: FormData) {
   }
 
 
-  const { transaction_id, orgId, type, description, category, amount, date,
+  const { transaction_id, org_id, type, description, category, amount, date,
     notes } = result.data;
 
   // Fetch existing transaction data before update for audit log
@@ -143,7 +133,7 @@ export async function updateTransaction(_prevState: any, formData: FormData) {
   const { data: afterData, error } = await supabase
     .from('transactions')
     .update({
-      org_id: orgId, date, description,
+      org_id, date, description,
       category, type, amount, notes
     })
     .eq("transaction_id", transaction_id)
@@ -151,7 +141,6 @@ export async function updateTransaction(_prevState: any, formData: FormData) {
     .single();
 
 
-  // TODO: Handle error better
   if (error) {
     console.error(error)
     return {
@@ -178,7 +167,7 @@ export async function updateTransaction(_prevState: any, formData: FormData) {
   // Only log if there are changes to the transaction data
   if (JSON.stringify(beforeData) !== JSON.stringify(afterData)) {
     await logAuditEntry({
-      orgId: orgId,
+      orgId: org_id,
       userId: beforeData.created_by,
       action: "UPDATE",
       entity_type: "transaction",
@@ -190,12 +179,11 @@ export async function updateTransaction(_prevState: any, formData: FormData) {
     });
   }
 
-
   revalidatePath('/transaction')
   redirect('/transaction')
 }
 
-export async function deleteTransaction(transaction_id: string, _formData: FormData) {
+export async function deleteTransaction(transaction_id: string, _formData: FormData) : Promise<ActionState> {
   const supabase = await createClient();
 
   // Fetch existing transaction data before deletion for audit log
@@ -207,7 +195,9 @@ export async function deleteTransaction(transaction_id: string, _formData: FormD
 
   if (beforeDataError || !beforeData) {
     console.error(beforeDataError);
-    return;
+    return {
+      message: `Error: ${beforeDataError}`
+    };
   }
 
   const { data: roleData, error: roleError } = await supabase
@@ -245,5 +235,3 @@ export async function deleteTransaction(transaction_id: string, _formData: FormD
 
   revalidatePath('/transaction')
 }
-
-export type Transaction = z.infer<typeof TransactionSchema>;

--- a/src/app/transaction/lib/actions.ts
+++ b/src/app/transaction/lib/actions.ts
@@ -7,7 +7,6 @@ import { fetchOrgFromCurrentUser, fetchUserId } from "@/app/transaction/lib/data
 import { z } from "zod";
 import { logAuditEntry } from "@/app/audit/lib/action";
 import { AuditLogType } from "@/app/audit/lib/data";
-// import { after, before } from "node:test";
 
 const TransactionSchema = z.object({
   transaction_id: z.uuid(),

--- a/src/app/transaction/lib/actions.ts
+++ b/src/app/transaction/lib/actions.ts
@@ -3,7 +3,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { fetchOrgFromCurrentUser, fetchUserId } from "@/app/transaction/lib/data";
+import { fetchUserId } from "@/app/transaction/lib/data";
 import { z } from "zod";
 import { logAuditEntry } from "@/app/audit/lib/action";
 import { AuditLogType } from "@/app/audit/lib/data";
@@ -13,11 +13,10 @@ const CreateTransactionSchema = TransactionsSchema.omit({ transaction_id: true }
 
 export async function createTransaction(_prevState: ActionState, formData: FormData) : Promise<ActionState> {
   const supabase = await createClient();
-  const fetchOrgId = await fetchOrgFromCurrentUser(); // TODO: Replace
   const userId = await fetchUserId();
 
   const result = CreateTransactionSchema.safeParse({
-    org_id: fetchOrgId,
+    org_id: formData.get("orgId"),
     type: formData.get("type"),
     description: formData.get("desc"),
     category: formData.get("category"),
@@ -58,7 +57,7 @@ export async function createTransaction(_prevState: ActionState, formData: FormD
   .from("org_members")
   .select("role")
   .eq("user_id", userId)
-  .eq("org_id", orgId)
+  .eq("org_id", org_id)
   .single()
 
   if(roleError) {
@@ -85,16 +84,15 @@ export async function createTransaction(_prevState: ActionState, formData: FormD
 
   revalidatePath('/transaction')
   revalidatePath("/dashboard");
-  redirect('/transaction')
+  redirect(`/transaction?orgId=${org_id}`)
 }
 
 export async function updateTransaction(_prevState: ActionState, formData: FormData) : Promise<ActionState> {
   const supabase = await createClient();
-  const fetchOrgId = await fetchOrgFromCurrentUser(); // TODO: Replace
 
   const result = TransactionsSchema.safeParse({
     transaction_id: formData.get("transId"),
-    orgId: fetchOrgId,
+    org_id: formData.get("orgId"),
     type: formData.get("type"),
     description: formData.get("desc"),
     category: formData.get("category"),
@@ -153,7 +151,7 @@ export async function updateTransaction(_prevState: ActionState, formData: FormD
   .from('org_members')
   .select('role') 
   .eq('user_id', beforeData.created_by)
-  .eq('org_id', orgId)
+  .eq('org_id', org_id)
   .single()
 
   if (roleError){
@@ -180,10 +178,13 @@ export async function updateTransaction(_prevState: ActionState, formData: FormD
   }
 
   revalidatePath('/transaction')
-  redirect('/transaction')
+  redirect(`/transaction?orgId=${org_id}`)
 }
 
-export async function deleteTransaction(transaction_id: string, _formData: FormData) : Promise<ActionState> {
+export async function deleteTransaction(
+  transaction_id: string,
+  _formData: FormData
+): Promise<void> {
   const supabase = await createClient();
 
   // Fetch existing transaction data before deletion for audit log
@@ -195,9 +196,9 @@ export async function deleteTransaction(transaction_id: string, _formData: FormD
 
   if (beforeDataError || !beforeData) {
     console.error(beforeDataError);
-    return {
-      message: `Error: ${beforeDataError}`
-    };
+    // return {
+    //   message: `Error: ${beforeDataError}`
+    // };
   }
 
   const { data: roleData, error: roleError } = await supabase
@@ -218,6 +219,7 @@ export async function deleteTransaction(transaction_id: string, _formData: FormD
     .eq("transaction_id", transaction_id);
   if (error) {
     console.error('Database Error: Failed to Delete Transaction.', error)
+    // return error;
   }
 
   // Insert audit log entry for transaction deletion

--- a/src/app/transaction/lib/data.ts
+++ b/src/app/transaction/lib/data.ts
@@ -128,7 +128,5 @@ export async function fetchOrgsOptionsFromCurrentUser() : Promise<OrgOptions[]> 
       role: org_members[0].role,
     }) )
 
-    console.warn(mappedData)
-
     return OrgOptionsSchema.array().parse(mappedData);
 }

--- a/src/app/transaction/lib/data.ts
+++ b/src/app/transaction/lib/data.ts
@@ -1,8 +1,10 @@
-"use server";
+"use server"
 
 import { createClient } from "@/lib/supabase/server";
 
-export async function fetchTransactions() {
+// Fetches all transactions across all orgs.
+// Returns: Transaction[]
+export async function fetchAllTransactions() {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('transactions')
@@ -16,8 +18,27 @@ export async function fetchTransactions() {
   return data;
 }
 
+// Fetches all transactions belonging to a specific org.
+// Returns: Transaction[]
+export async function fetchOrgTransactions(currentOrgId: string) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('transactions')
+    .select('*')
+    .eq("org_id", currentOrgId);
+
+  if (error) {
+    console.error('Database error:', error.message);
+    throw new Error('Failed to fetch transaction.');
+  }
+
+  return data;
+}
+
+// TODO: Phase out in favor of fetchOrgsFromCurrentUser() or fetchCurrentOrgFromURL() or OrgDropDownWrapper
+// Returns the org_id of the first org found for the current user
 export async function fetchOrgFromCurrentUser() {
-  // TODO: Supposes that a user is only in one org
     const supabase = await createClient();
     const userId = await fetchUserId();
 
@@ -35,6 +56,27 @@ export async function fetchOrgFromCurrentUser() {
     return data[0].org_id;
 }
 
+// Fetches all orgs the current user is a member of
+// Returns { org_id }[]
+export async function fetchOrgsFromCurrentUser() {
+    const supabase = await createClient();
+    const userId = await fetchUserId();
+
+    const { data, error } = await supabase
+      .from('org_members')
+      .select('org_id')
+      .eq("user_id", userId);
+
+    if (error) {
+      console.error('Database error:', error.message);
+      throw new Error('Failed to fetch org_id from user_id.');
+    }
+
+    return data;
+}
+
+// Returns the userId of the currently authenticated Supbase user.
+// Throws: If authenticated
 export async function fetchUserId() {
   const supabase = await createClient();
   const { data: {user} } = await supabase.auth.getUser();
@@ -46,6 +88,8 @@ export async function fetchUserId() {
   return user.id;
 }
 
+// Fetches a single transactions by its ID
+// Returns: Transaction or undefined if not found
 export async function fetchTransactionFromId(transactionId: string) {
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/src/app/transaction/lib/data.ts
+++ b/src/app/transaction/lib/data.ts
@@ -1,10 +1,11 @@
 "use server"
 
 import { createClient } from "@/lib/supabase/server";
+import { TransactionsSchema, OrgMembersSchema, type Transactions, type OrgMembers, OrgOptionsSchema, OrgOptions } from "@/app/transaction/lib/schemas";
 
 // Fetches all transactions across all orgs.
 // Returns: Transaction[]
-export async function fetchAllTransactions() {
+export async function fetchAllTransactions(): Promise<Transactions[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('transactions')
@@ -15,12 +16,12 @@ export async function fetchAllTransactions() {
     throw new Error('Failed to fetch transaction.');
   }
 
-  return data;
+  return TransactionsSchema.array().parse(data);
 }
 
 // Fetches all transactions belonging to a specific org.
 // Returns: Transaction[]
-export async function fetchOrgTransactions(currentOrgId: string) {
+export async function fetchOrgTransactions(currentOrgId: string): Promise<Transactions[]> {
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -33,12 +34,12 @@ export async function fetchOrgTransactions(currentOrgId: string) {
     throw new Error('Failed to fetch transaction.');
   }
 
-  return data;
+  return TransactionsSchema.array().parse(data);
 }
 
 // TODO: Phase out in favor of fetchOrgsFromCurrentUser() or fetchCurrentOrgFromURL() or OrgDropDownWrapper
 // Returns the org_id of the first org found for the current user
-export async function fetchOrgFromCurrentUser() {
+export async function fetchOrgFromCurrentUser() : Promise<OrgMembers> {
     const supabase = await createClient();
     const userId = await fetchUserId();
 
@@ -53,12 +54,12 @@ export async function fetchOrgFromCurrentUser() {
       throw new Error('Failed to fetch org_id from user_id.');
     }
 
-    return data[0].org_id;
+    return OrgMembersSchema.parse(data[0].org_id);
 }
 
 // Fetches all orgs the current user is a member of
 // Returns { org_id }[]
-export async function fetchOrgsFromCurrentUser() {
+export async function fetchOrgsFromCurrentUser() : Promise<OrgMembers[]> {
     const supabase = await createClient();
     const userId = await fetchUserId();
 
@@ -69,15 +70,15 @@ export async function fetchOrgsFromCurrentUser() {
 
     if (error) {
       console.error('Database error:', error.message);
-      throw new Error('Failed to fetch org_id from user_id.');
+      throw new Error('Failed to fetch orgs from user_id.');
     }
 
-    return data;
+    return OrgMembersSchema.array().parse(data);
 }
 
 // Returns the userId of the currently authenticated Supbase user.
 // Throws: If authenticated
-export async function fetchUserId() {
+export async function fetchUserId() : Promise<string>{
   const supabase = await createClient();
   const { data: {user} } = await supabase.auth.getUser();
 
@@ -90,7 +91,7 @@ export async function fetchUserId() {
 
 // Fetches a single transactions by its ID
 // Returns: Transaction or undefined if not found
-export async function fetchTransactionFromId(transactionId: string) {
+export async function fetchTransactionFromId(transactionId: string) : Promise<Transactions> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('transactions')
@@ -101,5 +102,33 @@ export async function fetchTransactionFromId(transactionId: string) {
     console.error('Database error:', error.message);
     throw new Error('Failed to fetch transaction from ID');
   }
-  return data[0];
+  return TransactionsSchema.parse(data[0]);
+}
+
+// Create function for fetching orgOptions
+export async function fetchOrgsOptionsFromCurrentUser() : Promise<OrgOptions[]> {
+    const supabase = await createClient();
+    const userId = await fetchUserId();
+
+    // data OrgOptionsSchema
+    const { data, error } = await supabase
+      .from('organizations')
+      .select(`org_id, 
+              org_name,
+              org_members!inner ( role )`)
+      .eq("org_members.user_id", userId);
+
+    if (error) {
+      console.error('Database error:', error.message);
+      throw new Error('Failed to fetch org options from user_id.');
+    }
+
+    const mappedData = data.map( ({ org_members, ...org }) => ({
+      ...org,
+      role: org_members[0].role,
+    }) )
+
+    console.warn(mappedData)
+
+    return OrgOptionsSchema.array().parse(mappedData);
 }

--- a/src/app/transaction/lib/schemas.ts
+++ b/src/app/transaction/lib/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+// Database
+
+export const TransactionsSchema = z.object({
+  transaction_id: z.uuid(),
+  org_id: z.uuid(),
+  date: z.coerce.date<string>().max(new Date(), "Date cannot be in future"),
+  description: z.string().nonempty("Please add description"),
+  category: z.string().nonempty("Please add category"),
+  type: z.enum(["income", "expense"]),
+  amount: z.coerce.number().positive("Amount must be greater than $0.00"),
+  notes: z.string().nullish(),
+  created_by: z.uuid().nullish(),
+});
+
+export const OrgMembersSchema = z.object({
+  user_id: z.uuid(),
+  org_id: z.uuid(),
+  role: z.enum(["member", "executive", "advisor", "treasury_team", "treasury_team", "treasurer", "admin"]),
+});
+
+export const OrganizationsSchema = z.object({
+  org_id: z.uuid(),
+  org_name: z.string(),
+  description: z.string().nullish(),
+  created_at: z.iso.datetime(),
+});
+
+// Extra
+
+export const ActionStateSchema = z.object({
+  errors: z.record( z.string(), z.array(z.string()) ).optional(),
+  message: z.union([z.string(), z.array(z.string()), z.undefined()]).optional(),
+}).nullish();
+
+export const OrgOptionsSchema = z.object({
+  ...OrganizationsSchema.pick({org_id: true, org_name: true}).shape,
+  ...OrgMembersSchema.pick({role: true}).shape,
+})
+
+// Database
+export type Transactions = z.infer<typeof TransactionsSchema>
+export type Organizations = z.infer<typeof OrganizationsSchema>
+export type OrgMembers = z.infer<typeof OrgMembersSchema>
+
+// Extra
+export type ActionState = z.infer<typeof ActionStateSchema>
+export type OrgOptions = z.infer<typeof OrgOptionsSchema>

--- a/src/app/transaction/page.tsx
+++ b/src/app/transaction/page.tsx
@@ -1,12 +1,25 @@
 import TransactionTable from "@/app/transaction/ui/table";
 import { CreateTransaction } from "@/app/transaction/ui/buttons";
 import { textColors } from "./lib/styles";
+import { fetchOrgTransactions, fetchOrgsFromCurrentUser } from "@/app/transaction/lib/data";
+import OrgDropDownWrapper from "@/components/OrgDropDownWrapper";
 
 export const metadata = { title: "Transactions" };
 
-export default function page() {
-  // TODO: Restrict display to only user_org
-  // TODO: Add layout page
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ orgId?: string }>
+}){
+  const organizations = await fetchOrgsFromCurrentUser();
+  const params = await searchParams;
+  const orgId = params?.orgId ?? (() => {
+    const fallback = organizations[0].org_id;
+    console.log("No searchParam 'orgId' found. \nFalling back to: ", fallback)
+    return fallback;
+  })();
+  const transactions = await fetchOrgTransactions(orgId);
+  
 
   return (
     <main className="max-w-7xl mx-auto px-4 py-8 pb-16">
@@ -16,13 +29,14 @@ export default function page() {
             <h1 className={`text-2xl font-semibold ${textColors.primary} mb-1`}>
               Transactions
             </h1>
+            <OrgDropDownWrapper organizations={organizations} />
             <p className={`${textColors.secondary}`}>
             </p>
           </div>
           <CreateTransaction />
         </div>
         <div>
-          <TransactionTable />
+          <TransactionTable transactions={transactions}/>
         </div>
       </div>
     </main>

--- a/src/app/transaction/page.tsx
+++ b/src/app/transaction/page.tsx
@@ -1,8 +1,9 @@
 import TransactionTable from "@/app/transaction/ui/table";
 import { CreateTransaction } from "@/app/transaction/ui/buttons";
 import { textColors } from "./lib/styles";
-import { fetchOrgTransactions, fetchOrgsFromCurrentUser } from "@/app/transaction/lib/data";
+import { fetchOrgTransactions, fetchOrgsOptionsFromCurrentUser } from "@/app/transaction/lib/data";
 import OrgDropDownWrapper from "@/components/OrgDropDownWrapper";
+import { type OrgOptions } from "./lib/schemas";
 
 export const metadata = { title: "Transactions" };
 
@@ -11,8 +12,9 @@ export default async function Page({
 }: {
   searchParams: Promise<{ orgId?: string }>
 }){
-  const organizations = await fetchOrgsFromCurrentUser();
+  const organizations : OrgOptions[] = await fetchOrgsOptionsFromCurrentUser();
   const params = await searchParams;
+  console.warn("Params", params)
   const orgId = params?.orgId ?? (() => {
     const fallback = organizations[0].org_id;
     console.log("No searchParam 'orgId' found. \nFalling back to: ", fallback)
@@ -20,7 +22,6 @@ export default async function Page({
   })();
   const transactions = await fetchOrgTransactions(orgId);
   
-
   return (
     <main className="max-w-7xl mx-auto px-4 py-8 pb-16">
       <div className="space-y-6">

--- a/src/app/transaction/page.tsx
+++ b/src/app/transaction/page.tsx
@@ -14,7 +14,6 @@ export default async function Page({
 }){
   const organizations : OrgOptions[] = await fetchOrgsOptionsFromCurrentUser();
   const params = await searchParams;
-  console.warn("Params", params)
   const orgId = params?.orgId ?? (() => {
     const fallback = organizations[0].org_id;
     console.log("No searchParam 'orgId' found. \nFalling back to: ", fallback)
@@ -30,14 +29,14 @@ export default async function Page({
             <h1 className={`text-2xl font-semibold ${textColors.primary} mb-1`}>
               Transactions
             </h1>
-            <OrgDropDownWrapper organizations={organizations} />
+            <OrgDropDownWrapper organizations={organizations} orgId={orgId} />
             <p className={`${textColors.secondary}`}>
             </p>
           </div>
-          <CreateTransaction />
+          <CreateTransaction orgId={orgId}/>
         </div>
         <div>
-          <TransactionTable transactions={transactions}/>
+          <TransactionTable transactions={transactions} orgId={orgId}/>
         </div>
       </div>
     </main>

--- a/src/app/transaction/ui/buttons.tsx
+++ b/src/app/transaction/ui/buttons.tsx
@@ -2,25 +2,25 @@ import Link from "next/link";
 import { deleteTransaction } from "@/app/transaction/lib/actions";
 import BackButton from "@/components/BackButton";
 
-export function CreateTransaction() {
+export function CreateTransaction({ orgId }: { orgId: string }) {
   // TODO: Add plus icon to button
   return (
     <div className="flex gap-4">
-    <Link href="transaction/create">
-      <button className="inline-flex items-center justify-center px-5 py-2 md:py-3 gap-2 rounded-lg bg-blue-500/80 text-gray-100 text-lg  transition-colors hover:bg-blue-500/90 cursor-pointer active:bg-blue-500">
-        +
-        <span className="hidden md:inline">Add Transaction</span>
-      </button>
-    </Link>
-    <BackButton></BackButton>
+      <Link href={`transaction/create?orgId=${orgId}`}>
+        <button className="inline-flex items-center justify-center px-5 py-2 md:py-3 gap-2 rounded-lg bg-blue-500/80 text-gray-100 text-lg  transition-colors hover:bg-blue-500/90 cursor-pointer active:bg-blue-500">
+          +
+          <span className="hidden md:inline">Add Transaction</span>
+        </button>
+      </Link>
+      <BackButton></BackButton>
     </div>
   );
 }
 
-export function UpdateTransaction({ id }: { id: string }) {
+export function UpdateTransaction({ id, orgId }: { id: string, orgId: string }) {
   // TODO: Add pencil icon
   return (
-    <Link href={`/transaction/${id}/edit`}>
+    <Link href={`/transaction/${id}/edit?orgId=${orgId}`}>
       <button className="w-11 h-8 rounded-md bg-orange-500/80 text-gray-100 text-xs transition-colors hover:bg-orange-500/90 cursor-pointer active:bg-orange-500">
         Edit
       </button>

--- a/src/app/transaction/ui/form.tsx
+++ b/src/app/transaction/ui/form.tsx
@@ -8,13 +8,14 @@ import type { Transactions } from "@/app/transaction/lib/schemas";
 
 // TODO: Only remove the field that had an error: keep repsonses for the rest
 
-export function CreateTransactionForm() {
+export function CreateTransactionForm({ orgId }: { orgId: string }) {
   const today = getToday();
   const [state, formAction] = useActionState(createTransaction, null);
 
   return (
     <form action={formAction}>
       <div>
+        <input type="hidden" name="orgId" value={orgId} />
         <label>Type</label>
         <select defaultValue="" name="type" required>
           <option value="" disabled>Select a type</option>
@@ -58,7 +59,7 @@ export function CreateTransactionForm() {
         />
         {state?.errors?.notes && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.notes[0]}</p>}
       </div>
-      <Link href="/transaction/">
+      <Link href={`/transaction?orgId=${orgId}`}>
         <span>Cancel</span>
       </Link>
       <button type="submit">Add Transaction</button>
@@ -67,18 +68,19 @@ export function CreateTransactionForm() {
   );
 }
 
-export function UpdateTransactionForm(transaction: {
+export function UpdateTransactionForm({ transaction, orgId }: {
   transaction: Transactions;
+  orgId: string;
 }) {
   const [state, formAction] = useActionState(updateTransaction, null);
-  const transObj = transaction.transaction;
 
   return (
     <form action={formAction}>
       <div>
-        <input type="hidden" name="transId" value={transObj.transaction_id} />
+        <input type="hidden" name="transId" value={transaction.transaction_id} />
+        <input type="hidden" name="orgId" value={orgId} />
         <label>Type</label>
-        <select defaultValue={transObj.type} name="type" required>
+        <select defaultValue={transaction.type} name="type" required>
           <option value="" disabled>Select a type</option>
           <option value="income">Income</option>
           <option value="expense">Expense</option>
@@ -88,39 +90,40 @@ export function UpdateTransactionForm(transaction: {
       <div>
         <label>Description</label>
         <input
-          type="text" name="desc" placeholder="e.g., Event Catering" defaultValue={transObj.description}
+          type="text" name="desc" placeholder="e.g., Event Catering" defaultValue={transaction.description}
         />
         {state?.errors?.description && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.description[0]}</p>}
       </div>
       <div>
         <label>Category</label>
         <input
-          type="text" name="category" placeholder="University Grant" defaultValue={transObj.category}
+          type="text" name="category" placeholder="University Grant" defaultValue={transaction.category}
         />
         {state?.errors?.category && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.category[0]}</p>}
       </div>
       <div>
         <label>Amount</label>
         <input
-          type="number" name="amount" placeholder="0.00" defaultValue={transObj.amount}
+          type="number" name="amount" placeholder="0.00" defaultValue={transaction.amount}
         />
         {state?.errors?.amount && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.amount[0]}</p>}
       </div>
       <div>
         <label>Date</label>
         <input
-          type="date" name="date" defaultValue={String(transObj.date)} required
+          // TODO: Find a better way of setting date string
+          type="date" name="date" defaultValue={transaction.date.toLocaleDateString('en-CA')} required
         />
         {state?.errors?.date && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.date[0]}</p>}
       </div>
       <div>
         <label>Notes</label>
         <input
-          type="text" name="notes" placeholder="Additional details..." defaultValue={transObj.notes}
+          type="text" name="notes" placeholder="Additional details..." defaultValue={transaction.notes ?? undefined}
         />
         {state?.errors?.notes && <p className={state.errors ? "text-red-500" : "text-green-500"}>{state.errors.notes[0]}</p>}
       </div>
-      <Link href="/transaction/">
+      <Link href={`/transaction?orgId=${orgId}`}>
         <span>Cancel</span>
       </Link>
       <button type="submit">Update Transaction</button>

--- a/src/app/transaction/ui/form.tsx
+++ b/src/app/transaction/ui/form.tsx
@@ -2,14 +2,15 @@
 
 import Link from "next/link";
 import { getToday } from "@/app/transaction/lib/util";
-import { createTransaction, type Transaction, updateTransaction } from "@/app/transaction/lib/actions";
+import { createTransaction, updateTransaction } from "@/app/transaction/lib/actions";
 import { useActionState } from "react";
+import type { Transactions } from "@/app/transaction/lib/schemas";
 
 // TODO: Only remove the field that had an error: keep repsonses for the rest
 
 export function CreateTransactionForm() {
   const today = getToday();
-  const [state, formAction] = useActionState(createTransaction, undefined);
+  const [state, formAction] = useActionState(createTransaction, null);
 
   return (
     <form action={formAction}>
@@ -67,12 +68,11 @@ export function CreateTransactionForm() {
 }
 
 export function UpdateTransactionForm(transaction: {
-  transaction: Transaction;
+  transaction: Transactions;
 }) {
-  const [state, formAction] = useActionState(updateTransaction, undefined);
+  const [state, formAction] = useActionState(updateTransaction, null);
   const transObj = transaction.transaction;
 
-  // TODO: Implement better way to pass transId
   return (
     <form action={formAction}>
       <div>

--- a/src/app/transaction/ui/table.tsx
+++ b/src/app/transaction/ui/table.tsx
@@ -3,7 +3,7 @@ import { textColors, bgColors } from "../lib/styles";
 import { type Transactions } from "@/app/transaction/lib/schemas";
 
 
-export default async function TransactionTable( { transactions } : { transactions: Transactions[] } ) {
+export default async function TransactionTable( { transactions, orgId } : { transactions: Transactions[], orgId: string } ) {
   // TODO: Add confirmation for DeleteTransaction
   const tableFieldSpacing = "px-3 py-1.5"
 
@@ -52,7 +52,7 @@ export default async function TransactionTable( { transactions } : { transaction
                   </td>
                   <td className={tableFieldSpacing}>
                     <div className="flex space-x-2">
-                      <UpdateTransaction id={transaction.transaction_id} />
+                      <UpdateTransaction id={transaction.transaction_id} orgId={orgId} />
                       <DeleteTransaction id={transaction.transaction_id} />
                     </div>
                   </td>

--- a/src/app/transaction/ui/table.tsx
+++ b/src/app/transaction/ui/table.tsx
@@ -1,8 +1,9 @@
 import { DeleteTransaction, UpdateTransaction } from "@/app/transaction/ui/buttons";
 import { textColors, bgColors } from "../lib/styles";
+import { type Transactions } from "@/app/transaction/lib/schemas";
 
 
-export default async function TransactionTable( { transactions } : { transactions: any[] } ) {
+export default async function TransactionTable( { transactions } : { transactions: Transactions[] } ) {
   // TODO: Add confirmation for DeleteTransaction
   const tableFieldSpacing = "px-3 py-1.5"
 
@@ -23,7 +24,7 @@ export default async function TransactionTable( { transactions } : { transaction
             {transactions.map((transaction) => {
               return (
                 <tr key={transaction.transaction_id} className={`${textColors.primary} odd:bg-white even:bg-gray-100 dark:odd:bg-black dark:even:bg-gray-900`}>
-                  <td className={tableFieldSpacing}>{transaction.date}</td>
+                  <td className={tableFieldSpacing}>{transaction.date.toLocaleDateString("en-US", {dateStyle: "long"})}</td>
                   <td className={tableFieldSpacing}>
                     <div>
                       <p>

--- a/src/app/transaction/ui/table.tsx
+++ b/src/app/transaction/ui/table.tsx
@@ -1,14 +1,11 @@
-import { fetchTransactions } from "@/app/transaction/lib/data";
 import { DeleteTransaction, UpdateTransaction } from "@/app/transaction/ui/buttons";
 import { textColors, bgColors } from "../lib/styles";
 
 
-export default async function TransactionTable() {
+export default async function TransactionTable( { transactions } : { transactions: any[] } ) {
   // TODO: Add confirmation for DeleteTransaction
-  // TODO: Add clsx for Color amount by type
   const tableFieldSpacing = "px-3 py-1.5"
 
-  const transactions = await fetchTransactions();
   return (
     <div className={`shadow-sm rounded-md ${bgColors.primary}`}>
       <div className="overflow-x-auto">

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useState, useRef, useEffect } from 'react'
+import { type OrgOptions } from '@/app/transaction/lib/schemas';
 
 type Props = {
   organizations: {
@@ -9,8 +10,8 @@ type Props = {
     org_name: string
     role: string
   }[]
-  currentOrgId: string
-  basePath: string
+    currentOrgId: string
+    basePath: string // e.g. '/dashboard' or '/files'
 }
 
 export default function OrgDropDown({ organizations, currentOrgId, basePath }: Props) {

--- a/src/components/OrgDropDownWrapper.tsx
+++ b/src/components/OrgDropDownWrapper.tsx
@@ -1,28 +1,21 @@
 'use client'
 
 import OrgDropDown from "@/components/OrgDropDown"
-import { useSearchParams } from "next/navigation";
 import { usePathname } from "next/navigation"
 import { type OrgOptions } from "@/app/transaction/lib/schemas"
 
-// Returns single orgId from URL
-// Default: Returns first orgId if no orgId found in URL
-export function fetchCurrentOrgFromURL(organizations : { org_id: string }[]) {
-  const searchParams = useSearchParams();
-  const orgIdFromURL = searchParams.get("orgId");
-  return orgIdFromURL ?? organizations[0].org_id;
-}
-
-export default function OrgDropDownWrapper( { organizations } : {organizations : OrgOptions[]}) {
-  const currentOrgId = fetchCurrentOrgFromURL(organizations);
+export default function OrgDropDownWrapper({ organizations, orgId }: {
+  organizations: OrgOptions[],
+  orgId: string
+}) {
   const basePath = usePathname();
 
-  if (!currentOrgId) return null;
+  if (!orgId) return null;
 
   return (
     <OrgDropDown
       organizations={organizations}
-      currentOrgId={currentOrgId}
+      currentOrgId={orgId}
       basePath={basePath}
     />
   );

--- a/src/components/OrgDropDownWrapper.tsx
+++ b/src/components/OrgDropDownWrapper.tsx
@@ -3,16 +3,7 @@
 import OrgDropDown from "@/components/OrgDropDown"
 import { useSearchParams } from "next/navigation";
 import { usePathname } from "next/navigation"
-
-type Org = {
-  org_id: string
-  org_name: string
-  role: string
-}
-
-type Props = {
-  organizations: Org[]
-}
+import { type OrgOptions } from "@/app/transaction/lib/schemas"
 
 // Returns single orgId from URL
 // Default: Returns first orgId if no orgId found in URL
@@ -22,7 +13,7 @@ export function fetchCurrentOrgFromURL(organizations : { org_id: string }[]) {
   return orgIdFromURL ?? organizations[0].org_id;
 }
 
-export default function OrgDropDownWrapper({ organizations }: Props) {
+export default function OrgDropDownWrapper( { organizations } : {organizations : OrgOptions[]}) {
   const currentOrgId = fetchCurrentOrgFromURL(organizations);
   const basePath = usePathname();
 

--- a/src/components/OrgDropDownWrapper.tsx
+++ b/src/components/OrgDropDownWrapper.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import OrgDropDown from "@/components/OrgDropDown"
+import { useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation"
+
+type Org = {
+  org_id: string
+  org_name: string
+  role: string
+}
+
+type Props = {
+  organizations: Org[]
+}
+
+// Returns single orgId from URL
+// Default: Returns first orgId if no orgId found in URL
+export function fetchCurrentOrgFromURL(organizations : { org_id: string }[]) {
+  const searchParams = useSearchParams();
+  const orgIdFromURL = searchParams.get("orgId");
+  return orgIdFromURL ?? organizations[0].org_id;
+}
+
+export default function OrgDropDownWrapper({ organizations }: Props) {
+  const currentOrgId = fetchCurrentOrgFromURL(organizations);
+  const basePath = usePathname();
+
+  if (!currentOrgId) return null;
+
+  return (
+    <OrgDropDown
+      organizations={organizations}
+      currentOrgId={currentOrgId}
+      basePath={basePath}
+    />
+  );
+}


### PR DESCRIPTION
## Description
<!-- One sentence description -->
Added organization scoping to transactions pages
---

## Changes
- Added OrgDropDown to Transactions page
- Changed Transactions table to only display entries from org
- Added proper types to 'transaction/lib/actions.ts' and 'transaction/lib/data.ts'
- Added 'fetchOrgOptionsFromCurrentUser' function to 'data.ts'
- Change date format in Transactions Table 
- CreateTransaction fetches orgId from params and redirects to proper orgId
- EditTransaction fetches orgId from params and redirects to proper orgId
---

## How to Test
1. Log in with U: multiorg@test.com P: Test1234!
2. Navigate to Transactions
3. Click 'Change Organizations' and notice that the table changes
4. Add a transaction
5. Edit that transaction
6. Delete that transaction

---

## Screenshots
<!-- Only if you changed the UI - drag and drop images here -->

---

## Checklist
<!-- Mark with an X -->
- [ X ] Tested locally
- [ X ] No errors in console