### PR TITLE
General improvements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,13 @@
 
 ---
 
+## Issues Addressed
+<!-- Closes <Issue number> -->
+<!-- Closes <Issue number 2> -->
+<!-- Partially Addresses <Issue number> -->
+
+---
+
 ## Changes
 - 
 - 

--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { createClient } from '../../lib/supabase/client'
-import { getFiles } from '../../lib/files'
 import UploadModal from '../../components/UploadModal'
 import FileViewer from '../../components/FileViewer'
 import BackButton from '@/components/BackButton'
@@ -11,6 +10,8 @@ import BackButton from '@/components/BackButton'
 import OrgDropDown from '@/components/OrgDropDown'
 import { Skeleton } from '@/components/Skeleton'
 import { canUploadFiles, canViewFiles } from '@/lib/roles'
+import { getFiles, deleteFile } from '../../lib/files'
+
 
 
 type OrgOption = {
@@ -110,6 +111,7 @@ function FilesPageContent() {
 
     const canAccessFiles = canViewFiles(role)
     const canUpload = canUploadFiles(role)
+    const canDelete = canUploadFiles(role)
 
     const filteredFiles = files.filter((file) => {
         if (typeFilter !== 'all' && file.file_type !== typeFilter) return false
@@ -148,7 +150,7 @@ function FilesPageContent() {
                     <Skeleton width={64} height={28} />
                     <Skeleton width={112} height={38} rounded="sm" />
                 </div>
- 
+
                 {/* Filters */}
                 <div className="flex flex-wrap gap-4 mb-6">
                     <div className="flex gap-2">
@@ -163,7 +165,7 @@ function FilesPageContent() {
                         <Skeleton width={128} height={38} rounded="sm" />
                     </div>
                 </div>
- 
+
                 {/* File list */}
                 <ul className="divide-y border rounded-lg">
                     {Array.from({ length: 5 }).map((_, i) => (
@@ -344,16 +346,34 @@ function FilesPageContent() {
                                     {file.file_type} · {new Date(file.uploaded_at).toLocaleDateString()}
                                 </p>
                             </div>
-                            <button
-                                onClick={() => setViewingFile({
-                                    filePath: file.file_path,
-                                    fileName: file.file_name,
-                                    mimeType: file.mime_type,
-                                })}
-                                className="text-blue-600 text-sm"
-                            >
-                                View
-                            </button>
+                            <div className="flex items-center gap-3">
+                                <button
+                                    onClick={() => setViewingFile({
+                                        filePath: file.file_path,
+                                        fileName: file.file_name,
+                                        mimeType: file.mime_type,
+                                    })}
+                                    className="text-blue-400 text-sm hover:text-blue-300 transition"
+                                >
+                                    View
+                                </button>
+                                {canDelete && (
+                                    <button
+                                        onClick={async () => {
+                                            if (!confirm(`Delete "${file.file_name}"?`)) return
+                                            try {
+                                                await deleteFile(file.file_id, file.file_path)
+                                                await loadFiles()
+                                            } catch {
+                                                setError('Failed to delete file')
+                                            }
+                                        }}
+                                        className="text-red-400 text-sm hover:text-red-300 transition"
+                                    >
+                                        Delete
+                                    </button>
+                                )}
+                            </div>
                         </li>
                     ))}
                 </ul>
@@ -375,6 +395,9 @@ function FilesPageContent() {
 //         </Suspense>
 //     )
 // }
+
+// export const metadata = { title: "Files" };
+
 
 export default function FilesPage() {
     return (

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -6,10 +6,10 @@ export default function BackButton({ label = "Go Back" }: { label?: string }) {
 
     return (
         <button
-        // changed to make it visible in white mode - prabh--
-            onClick={() => router.push("/dashboard")}
+            // changed to make it visible in white mode - prabh--
+            onClick={() => router.push("/")}
             className="rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 transition hover:bg-gray-100 active:scale-95 dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white dark:hover:bg-white/[0.08]"
-        > 
+        >
             {label}
         </button>
     );


### PR DESCRIPTION
## Description
Two small but important fixes — BackButton was 404ing on every page, and uploaded files had no way to be deleted through the UI.

---

## Issues Addressed
Closes #112 
Closes #114

---

## Changes
- BackButton now navigates to "/" instead of "/dashboard"
- Added Delete button to files page, only visible to treasury_team, treasurer, and admin
- Delete requires a confirmation prompt before proceeding
- Updated PR template as well to improve documentation

---

## How to Test
1. Click Go Back on any page — should land on dashboard instead of 404
2. Log in as treasurer@test.com, go to Files, upload a file
3. Confirm Delete button appears and successfully removes the file
4. Log in as executive@test.com and confirm Delete button is not visible

---

## Screenshots
<img width="970" height="545" alt="image" src="https://github.com/user-attachments/assets/c0741bd3-794b-4b2a-8aff-9c7fe4b885da" />

---

## Checklist
- [X] Tested locally
- [X] No errors in console