### PR TITLE
Add organization logo display and edit functionality

### DIFF
--- a/src/app/organizations/[orgId]/members/page.tsx
+++ b/src/app/organizations/[orgId]/members/page.tsx
@@ -1,4 +1,8 @@
 import Link from "next/link";
+import BackButton from "@/components/BackButton";
+import Image from "next/image";
+import { createClient } from "@/lib/supabase/server";
+
 import {
   getOrganizationById,
   getOrganizationMembers,
@@ -29,6 +33,7 @@ export default async function OrganizationMembersPage({
 }: MembersPageProps) {
   const { orgId } = await params;
   const { error, success } = await searchParams;
+  const supabase = await createClient();
 
   // Still protect the page itself, same as PR1.
   const currentMembership =
@@ -39,6 +44,23 @@ export default async function OrganizationMembersPage({
     getOrganizationById(orgId),
     getOrganizationMembers(orgId),
   ]);
+
+  let signedLogoUrl: string | null = null;
+
+  if (organization?.logo_path) {
+    const { data } = await supabase.storage
+      .from("organization-logos")
+      .createSignedUrl(organization.logo_path, 60 * 60);
+
+    signedLogoUrl = data?.signedUrl ?? null;
+  }
+  if (!organization) {
+    return (
+      <main className="min-h-screen bg-black p-6 text-white">
+        <p>Organization not found.</p>
+      </main>
+    );
+  }
 
   // Bind orgId once so the forms can just call the actions directly.
   const addMemberForOrganization = addOrganizationMember.bind(null, orgId);
@@ -60,10 +82,48 @@ export default async function OrganizationMembersPage({
             </p>
           </div>
 
-          <Link href="/organizations" className="underline">
-            Back to Organizations
+          <div className="flex items-center gap-2 mb-4">
+            <Link
+              href={`/?orgId=${orgId}`}
+              className="rounded-lg border border-white/20 px-4 py-2 text-sm text-white hover:bg-white/10 transition"
+            >
+              Dashboard
+            </Link>
+
+            <Link
+              href="/organizations"
+              className="rounded-lg border border-white/20 px-4 py-2 text-sm text-white hover:bg-white/10 transition"
+            >
+              All Organizations
+            </Link>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center justify-center gap-3 text-center">
+          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border border-white/20 bg-white/5 sm:h-28 sm:w-28 md:h-32 md:w-32">
+            {signedLogoUrl ? (
+              <Image
+                src={signedLogoUrl}
+                alt={`${organization.org_name} logo`}
+                width={128}
+                height={128}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-2xl font-semibold text-white md:text-3xl">
+                {organization.org_name.slice(0, 2).toUpperCase()}
+              </span>
+            )}
+          </div>
+
+          <Link
+            href={`/organizations/${organization.org_id}/settings`}
+            className="rounded-lg border border-white/20 px-4 py-2 text-sm text-white transition hover:bg-white/10"
+          >
+            Edit Logo
           </Link>
         </div>
+
 
         {success && (
           <div className="rounded border border-green-500/50 bg-green-500/10 p-3 text-sm text-green-200">

--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -21,6 +21,7 @@ export type OrganizationMembership = {
 export type OrganizationSummary = {
   org_id: string;
   org_name: string;
+  logo_path: string | null; // to show logo
 };
 
 export type OrganizationMemberUser = {
@@ -103,7 +104,7 @@ export async function getOrganizationById(orgId: string) {
 
   const result = await supabase
     .from("organizations")
-    .select("org_id, org_name")
+    .select("org_id, org_name, logo_path")
     .eq("org_id", orgId)
     .maybeSingle();
 


### PR DESCRIPTION
## Description
Add organization logo display, edit logo navigation, and dashboard redirect buttons on Organization Page.

---

## Issues Addressed
* #125 Closes Issue
* #72 Addresses Issue

---

## Changes
- Displayed organization logo in a responsive circular layout
- Added fallback initials when no logo exists
- Added an "Edit Logo" button that redirects to the organization settings page
- Added dashboard navigation buttons so users can return to the dashboard without manually typing the URL
- Updated organization data fetching to include `logo_path`

---

## How to Test
1. Navigate to an organization page and verify the logo or fallback initials appear.
2. Click "Edit Logo" and confirm it redirects to the organization settings page.
3. Click the dashboard button and confirm it redirects back to the dashboard.

---

## Screenshots
Displays feature implementation onto org page as well as new button redirect and renaming for navigation
<img width="751" height="511" alt="Screenshot 2026-04-30 at 11 14 27 AM" src="https://github.com/user-attachments/assets/58f97325-6187-4966-927a-7f687f265e21" />


---

## Checklist
- [X] Tested locally
- [X] No errors in console