### PR TITLE
fix Playwright's env vars for Playwright webServer

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,5 +77,10 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    },
   },
 });


### PR DESCRIPTION
Playwright's webServer config was spawning npm run dev without inheriting the GitHub Actions secret env vars, causing the Next.js middleware to crash on startup with 'Your project's URL and Key are required to create a Supabase client'. Adding explicit env passthrough should fix this.

This is likely what's been causing PR #124 (Mathew issue59 completion) to fail Playwright on every merge attempt.