### PR TITLE
Fixed six functionality issues that surfaced during DP3 testing.

### DIFF
--- a/src/app/organizations/[orgId]/settings/actions.ts
+++ b/src/app/organizations/[orgId]/settings/actions.ts
@@ -29,7 +29,7 @@ export async function updateOrganizationLogo(
     .eq("user_id", user.id)
     .single();
 
-  const allowedRoles = ["treasurer", "advisor"];
+  const allowedRoles = ["treasurer", "advisor", "executive", "admin"];
 
   if (!membership || !allowedRoles.includes(membership.role.toLowerCase())) {
     throw new Error("No permission");

--- a/src/app/organizations/[orgId]/settings/page.tsx
+++ b/src/app/organizations/[orgId]/settings/page.tsx
@@ -38,7 +38,7 @@ export default async function OrgSettingsPage({
     .eq("user_id", user.id)
     .single();
 
-  const allowedRoles = ["treasurer", "advisor"];
+  const allowedRoles = ["treasurer", "advisor", "executive", "admin"];
 
   if (!membership || !allowedRoles.includes(membership.role.toLowerCase())) {
     redirect(`/?orgId=${orgId}`);

--- a/src/app/organizations/new/layout.tsx
+++ b/src/app/organizations/new/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "New Organization" };
+
+export default function FilesLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}

--- a/src/app/organizations/new/page.tsx
+++ b/src/app/organizations/new/page.tsx
@@ -1,10 +1,23 @@
-import Form from 'next/form'
-import { createOrganization } from "./actions";
-import Link from "next/link";
+"use client";
 
-export const metadata = { title: "New Organization" };
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createOrganization } from "./actions";
 
 export default function NewOrganization() {
+    const [isPending, startTransition] = useTransition();
+    const [name, setName] = useState("");
+    const router = useRouter();
+
+    function handleSubmit(formData: FormData) {
+        startTransition(async () => {
+            await createOrganization(formData);
+            // Once create succeeds, send user back to org list (which will show the new org)
+            router.push("/organizations");
+        });
+    }
+
     return (
         <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
             <section className="w-full max-w-sm rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 shadow-[0_0_20px_rgba(255,255,255,0.05)] backdrop-blur-sm">
@@ -15,19 +28,23 @@ export default function NewOrganization() {
                     New Organization
                 </h1>
 
-                <Form action={createOrganization} className="flex flex-col gap-3">
+                <form action={handleSubmit} className="flex flex-col gap-3">
                     <input
                         name="organizationName"
                         type="text"
                         required
+                        disabled={isPending}
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
                         placeholder="Organization name"
-                        className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
                     />
                     <button
                         type="submit"
-                        className="w-full rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20"
+                        disabled={isPending || !name.trim()}
+                        className="w-full rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                        Create Organization
+                        {isPending ? "Creating..." : "Create Organization"}
                     </button>
                     <Link
                         href="/organizations"
@@ -35,7 +52,7 @@ export default function NewOrganization() {
                     >
                         Go Back
                     </Link>
-                </Form>
+                </form>
             </section>
         </main>
     );

--- a/src/app/quotes/actions.ts
+++ b/src/app/quotes/actions.ts
@@ -3,31 +3,43 @@
 import { createClient } from "@/lib/supabase/server";
 import { AuditLogType } from "../audit/lib/data";
 import { logAuditEntry } from "../audit/lib/action";
-import { after, before } from "node:test";
-import { Supermercado_One } from "next/font/google";
 
-export async function getQuotes(orgId: string){
+export async function getQuotes(orgId: string) {
     const supabase = await createClient();
 
-    const {data, error} = await supabase
+    const { data, error } = await supabase
         .from("quotes")
         .select("*")
-        .eq("org_id", orgId)
+        .eq("org_id", orgId);
 
-    if(error){
+    if (error) {
         return { error: error.message };
     }
-    return {data};
+    return { data };
+}
+
+// Returns the current user's role in the given org, or null if not a member
+export async function getCurrentUserRole(orgId: string): Promise<string | null> {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return null;
+
+    const { data } = await supabase
+        .from("org_members")
+        .select("role")
+        .eq("org_id", orgId)
+        .eq("user_id", user.id)
+        .single();
+
+    return data?.role ?? null;
 }
 
 // adds new quote to database
-export async function addQuote(vendor: string, memo: string, amount: number, orgId : string){
+export async function addQuote(vendor: string, memo: string, amount: number, orgId: string) {
     const supabase = await createClient();
 
-    console.log("Attempting insert with:", { vendor, memo, amount, orgId })
-
-    const {data, error} = await supabase.from("quotes")
-    
+    const { data, error } = await supabase
+        .from("quotes")
         .insert({
             vendor: vendor,
             memo: memo,
@@ -36,29 +48,30 @@ export async function addQuote(vendor: string, memo: string, amount: number, org
         })
         .select()
         .single();
-        
-    console.log("Result:", { data, error })
 
-    if(error){
+    if (error) {
         return { error: error.message };
+    }
+
+    if (!data) {
+        return { error: "Quote was not created. You may not have permission to add quotes." };
     }
 
     // Grab the role of the current user of the current organization
     const { data: roleData, error: roleError } = await supabase
-    .from("org_members")
-    .select('role')
-    .eq('org_id', orgId)
-    .eq('user_id', data.uploaded_by)
-    .single();
+        .from("org_members")
+        .select("role")
+        .eq("org_id", orgId)
+        .eq("user_id", data.uploaded_by)
+        .single();
 
     if (roleError) {
         console.error("Failed to fetch user's role.");
         return { error: roleError.message };
     }
 
-    // Insert entry to audit logs
     await logAuditEntry({
-        orgId:orgId,
+        orgId: orgId,
         userId: data.uploaded_by,
         action: "CREATE",
         entity_type: "quote",
@@ -71,18 +84,15 @@ export async function addQuote(vendor: string, memo: string, amount: number, org
             "STATUS": "PENDING",
         },
         type: AuditLogType.FINANCIAL,
-        display_role: roleData?.role
+        display_role: roleData?.role,
     });
 
-
-    return { data }
-
+    return { data };
 }
 
 // marks as accepted
 export async function acceptQuote(id: number) {
     const supabase = await createClient();
-
 
     const { data, error } = await supabase
         .from("quotes")
@@ -91,76 +101,82 @@ export async function acceptQuote(id: number) {
         .select()
         .single();
 
-    if (error){
+    if (error) {
         return { error: error.message };
     }
 
-    // Grabs the role of the current user of the current organization
-    const { data: roleData, error:roleError } = await supabase
-    .from("org_members")
-    .select('role')
-    .eq("user_id", data.uploaded_by)
-    .eq("org_id", data.org_id)
-    .single()
-
-    if (roleError) {
-        console.error("Failed to fetch user's role.")
+    if (!data) {
+        return { error: "Quote was not updated. You may not have permission to accept this quote." };
     }
 
-    // Insert into audit log
-    // TODO: Needs Improvement
+    // Grabs the role of the current user of the current organization
+    const { data: roleData, error: roleError } = await supabase
+        .from("org_members")
+        .select("role")
+        .eq("user_id", data.uploaded_by)
+        .eq("org_id", data.org_id)
+        .single();
+
+    if (roleError) {
+        console.error("Failed to fetch user's role.");
+    }
+
     await logAuditEntry({
         orgId: data.org_id,
         userId: data.uploaded_by,
         action: "UPDATE",
         entity_type: "quote",
         entity_id: data.quotes_id,
-        before_data: {"STATUS": "PENDING"},
-        after_data: {"STATUS": "ACCEPTED"},
+        before_data: { "STATUS": "PENDING" },
+        after_data: { "STATUS": "ACCEPTED" },
         type: AuditLogType.FINANCIAL,
-        display_role:roleData?.role,
+        display_role: roleData?.role,
     });
 
+    return { data };
 }
 
 // deleting quotes
-export async function deleteQuote(id: number){
+export async function deleteQuote(id: number) {
     const supabase = await createClient();
 
-    // Grab the session user information
-    const {data: {user} } = await supabase.auth.getUser();
+    const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
-        throw new Error("User must be authenticated to delete quotes.");
+        return { error: "User must be authenticated to delete quotes." };
     }
 
+    const { data: beforeData, error: beforeError } = await supabase
+        .from("quotes")
+        .select()
+        .eq("quotes_id", id)
+        .single();
 
-    const {data: beforeData, error: beforeError } = await supabase
-    .from("quotes")
-    .select()
-    .eq("quotes_id", id)
-    .single();
-
-    if (beforeError) {
-        console.error("Unable to fetch data before deletion.")
-        return { error: beforeError.message };
+    if (beforeError || !beforeData) {
+        return { error: "Unable to fetch quote (it may not exist or you may not have access)." };
     }
 
-    const { error } = await supabase
+    // Use .select() to confirm rows actually got deleted
+    const { data: deletedRows, error } = await supabase
         .from("quotes")
         .delete()
-        .eq("quotes_id", id); // check id
-    if(error){
-        return {
-            error: error.message };
-        }
+        .eq("quotes_id", id)
+        .select();
+
+    if (error) {
+        return { error: error.message };
+    }
+
+    if (!deletedRows || deletedRows.length === 0) {
+        return { error: "Quote was not deleted. You may not have permission to delete this quote." };
+    }
 
     // Grab the role of the user of the current organization
     const { data: roleData, error: roleError } = await supabase
-    .from("org_members")
-    .select('role')
-    .eq("user_id", user.id)
-    .eq("org_id", beforeData.org_id)
-    .single();
+        .from("org_members")
+        .select("role")
+        .eq("user_id", user.id)
+        .eq("org_id", beforeData.org_id)
+        .single();
 
     if (roleError) {
         console.error("Failed to fetch user's role.");
@@ -183,4 +199,6 @@ export async function deleteQuote(id: number){
         type: AuditLogType.FINANCIAL,
         display_role: roleData.role,
     });
+
+    return { data: deletedRows[0] };
 }

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -1,10 +1,14 @@
 "use client"
 
 import { useEffect, useState, Suspense } from "react"
-import { addQuote, getQuotes, acceptQuote, deleteQuote } from "./actions"
+import { addQuote, getQuotes, acceptQuote, deleteQuote, getCurrentUserRole } from "./actions"
 import BackButton from "@/components/BackButton"
 import { Skeleton } from "@/components/Skeleton"
 import { useSearchParams } from "next/navigation"
+
+const VIEW_ROLES = ["executive", "advisor", "treasury_team", "treasurer", "admin"]
+const MANAGE_ROLES = ["treasury_team", "treasurer", "admin"]
+const DELETE_ROLES = ["treasurer", "admin"]
 
 type SkeletonPulseProps = { className?: string }
 function SkeletonPulse({ className = "" }: SkeletonPulseProps) {
@@ -31,6 +35,11 @@ function QuotesPageContent() {
     const [error, setError] = useState("")
     const [loading, setLoading] = useState(true)
     const [confirmingId, setConfirmingId] = useState<number | null>(null)
+    const [userRole, setUserRole] = useState<string | null>(null)
+
+    const canView = !!userRole && VIEW_ROLES.includes(userRole.toLowerCase())
+    const canManage = !!userRole && MANAGE_ROLES.includes(userRole.toLowerCase())
+    const canDelete = !!userRole && DELETE_ROLES.includes(userRole.toLowerCase())
 
     async function handleDeleteQuote(id: number) {
         const result = await deleteQuote(id)
@@ -42,18 +51,33 @@ function QuotesPageContent() {
     }
 
     async function fetchQuotes() {
-        if (!orgID) return
-        const result = await getQuotes(orgID)
-        if (result?.error) {
-            setError(result.error)
-        } else if (result?.data) {
-            setQuotes(result.data)
+        if (!orgID) {
+            setLoading(false);
+            return;
         }
-        setLoading(false)
+        try {
+            const result = await getQuotes(orgID);
+            if (result?.error) {
+                setError(result.error);
+            } else if (result?.data) {
+                setQuotes(result.data);
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load quotes");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function fetchUserRole() {
+        if (!orgID) return
+        const role = await getCurrentUserRole(orgID)
+        setUserRole(role)
     }
 
     useEffect(() => {
         fetchQuotes()
+        fetchUserRole()
     }, [])
 
     async function handleAddQuote() {
@@ -92,133 +116,168 @@ function QuotesPageContent() {
                     <BackButton />
                 </div>
 
-                {/* Add Quote Form */}
-                <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-6 backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)] mb-8">
-                    <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white mb-4">Add Quote</h2>
+                {/* Access denied state */}
+                {!loading && !canView && (
+                    <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 text-center backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)]">
+                        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                            Access denied
+                        </h2>
+                        <p className="text-sm text-gray-500 dark:text-neutral-400">
+                            You don&apos;t have permission to view quotes for this organization.
+                        </p>
+                    </section>
+                )}
 
-                    <div className="flex flex-col gap-3">
-                        {loading ? (
-                            <>
-                                <SkeletonPulse className="h-9 w-full" />
-                                <SkeletonPulse className="h-20 w-full" />
-                                <SkeletonPulse className="h-9 w-full" />
-                                <SkeletonPulse className="h-9 w-24" />
-                            </>
-                        ) : (
-                            <>
-                                <input
-                                    type="text"
-                                    placeholder="Vendor"
-                                    value={vendor}
-                                    onChange={(e) => setVendor(e.target.value)}
-                                    className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                />
-                                <textarea
-                                    placeholder="Memo"
-                                    value={memo}
-                                    onChange={(e) => setMemo(e.target.value)}
-                                    className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-                                    rows={3}
-                                />
-                                <input
-                                    type="number"
-                                    placeholder="Amount"
-                                    value={amount}
-                                    onChange={(e) => setAmount(e.target.value)}
-                                    className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                />
-                                <button
-                                    onClick={handleAddQuote}
-                                    className="self-start rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20"
-                                >
-                                    Add Quote
-                                </button>
-                            </>
-                        )}
-                    </div>
-                </section>
+                {/* Main content */}
+                {(loading || canView) && (
+                    <>
+                        {/* Add Quote Form (only for users with manage permission) */}
+                        {(loading || canManage) && (
+                            <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-6 backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)] mb-8">
+                                <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white mb-4">Add Quote</h2>
 
-                {/* Quotes List */}
-                <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)] overflow-hidden">
-                    <div className="px-6 py-4 border-b border-gray-100 dark:border-white/[0.08]">
-                        <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">Submitted Quotes</h2>
-                    </div>
-
-                    {loading ? (
-                        <div className="divide-y divide-gray-100 dark:divide-white/[0.08]">
-                            {Array.from({ length: 3 }).map((_, i) => (
-                                <div key={i} className="flex justify-between items-center px-6 py-4">
-                                    <div className="flex flex-col gap-2">
-                                        <SkeletonPulse className="h-4 w-28" />
-                                        <SkeletonPulse className="h-3 w-48" />
-                                    </div>
-                                    <div className="flex items-center gap-4">
-                                        <SkeletonPulse className="h-4 w-12" />
-                                        <SkeletonPulse className="h-7 w-16 rounded" />
-                                        <SkeletonPulse className="h-7 w-16 rounded" />
-                                    </div>
+                                <div className="flex flex-col gap-3">
+                                    {loading ? (
+                                        <>
+                                            <SkeletonPulse className="h-9 w-full" />
+                                            <SkeletonPulse className="h-20 w-full" />
+                                            <SkeletonPulse className="h-9 w-full" />
+                                            <SkeletonPulse className="h-9 w-24" />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <input
+                                                type="text"
+                                                placeholder="Vendor"
+                                                value={vendor}
+                                                onChange={(e) => setVendor(e.target.value)}
+                                                className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                            />
+                                            <textarea
+                                                placeholder="Memo"
+                                                value={memo}
+                                                onChange={(e) => setMemo(e.target.value)}
+                                                className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                                                rows={3}
+                                            />
+                                            <input
+                                                type="number"
+                                                placeholder="Amount"
+                                                value={amount}
+                                                onChange={(e) => setAmount(e.target.value)}
+                                                className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                            />
+                                            <button
+                                                onClick={handleAddQuote}
+                                                className="self-start rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20"
+                                            >
+                                                Add Quote
+                                            </button>
+                                        </>
+                                    )}
                                 </div>
-                            ))}
-                        </div>
-                    ) : quotes.length === 0 ? (
-                        <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-neutral-400">
-                            No quotes yet.
-                        </div>
-                    ) : (
-                        <ul className="divide-y divide-gray-100 dark:divide-white/[0.08]">
-                            {quotes.map((q) => (
-                                <li key={q.quotes_id} className="flex justify-between items-center px-6 py-4 transition hover:bg-gray-50 dark:hover:bg-white/[0.03]">
-                                    <div>
-                                        <p className="text-sm font-medium text-gray-900 dark:text-white">{q.vendor}</p>
-                                        <p className="text-xs text-gray-500 dark:text-neutral-400 mt-0.5">{q.memo}</p>
-                                    </div>
-                                    <div className="flex items-center gap-4">
-                                        <span className="text-sm font-medium text-gray-900 dark:text-white">
-                                            ${q.amount.toLocaleString()}
-                                        </span>
+                            </section>
+                        )}
 
-                                        {!q.accepted ? (
-                                            <button
-                                                onClick={() => handleAcceptQuote(q.quotes_id)}
-                                                className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-600 dark:text-neutral-300 transition hover:border-green-400 hover:text-green-600 dark:hover:text-green-400"
-                                            >
-                                                Accept
-                                            </button>
-                                        ) : (
-                                            <span className="text-xs font-medium text-green-600 dark:text-green-400">Accepted</span>
-                                        )}
+                        {/* Error banner - moved up to be visible without scrolling */}
+                        {error && (
+                            <div className="mb-8 flex items-start justify-between gap-3 rounded-xl border border-red-300 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-300">
+                                <span>{error}</span>
+                                <button
+                                    onClick={() => setError("")}
+                                    className="text-red-700 dark:text-red-300 hover:opacity-70"
+                                    aria-label="Dismiss error"
+                                >
+                                    ×
+                                </button>
+                            </div>
+                        )}
 
-                                        {confirmingId === q.quotes_id ? (
-                                            <div className="flex items-center gap-2">
-                                                <button
-                                                    onClick={() => { handleDeleteQuote(q.quotes_id); setConfirmingId(null) }}
-                                                    className="rounded-xl border border-red-400/50 px-3 py-1 text-xs font-medium text-red-500 dark:text-red-400 transition hover:bg-red-50 dark:hover:bg-red-500/10"
-                                                >
-                                                    Confirm
-                                                </button>
-                                                <button
-                                                    onClick={() => setConfirmingId(null)}
-                                                    className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-500 dark:text-neutral-400 transition hover:bg-gray-50 dark:hover:bg-white/[0.05]"
-                                                >
-                                                    Cancel
-                                                </button>
+                        {/* Quotes List */}
+                        <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)] overflow-hidden">
+                            <div className="px-6 py-4 border-b border-gray-100 dark:border-white/[0.08]">
+                                <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">Submitted Quotes</h2>
+                            </div>
+
+                            {loading ? (
+                                <div className="divide-y divide-gray-100 dark:divide-white/[0.08]">
+                                    {Array.from({ length: 3 }).map((_, i) => (
+                                        <div key={i} className="flex justify-between items-center px-6 py-4">
+                                            <div className="flex flex-col gap-2">
+                                                <SkeletonPulse className="h-4 w-28" />
+                                                <SkeletonPulse className="h-3 w-48" />
                                             </div>
-                                        ) : (
-                                            <button
-                                                onClick={() => setConfirmingId(q.quotes_id)}
-                                                className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-500 dark:text-neutral-400 transition hover:border-red-400/50 hover:text-red-500 dark:hover:text-red-400"
-                                            >
-                                                Delete
-                                            </button>
-                                        )}
-                                    </div>
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </section>
+                                            <div className="flex items-center gap-4">
+                                                <SkeletonPulse className="h-4 w-12" />
+                                                <SkeletonPulse className="h-7 w-16 rounded" />
+                                                <SkeletonPulse className="h-7 w-16 rounded" />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : quotes.length === 0 ? (
+                                <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-neutral-400">
+                                    No quotes yet.
+                                </div>
+                            ) : (
+                                <ul className="divide-y divide-gray-100 dark:divide-white/[0.08]">
+                                    {quotes.map((q) => (
+                                        <li key={q.quotes_id} className="flex justify-between items-center px-6 py-4 transition hover:bg-gray-50 dark:hover:bg-white/[0.03]">
+                                            <div>
+                                                <p className="text-sm font-medium text-gray-900 dark:text-white">{q.vendor}</p>
+                                                <p className="text-xs text-gray-500 dark:text-neutral-400 mt-0.5">{q.memo}</p>
+                                            </div>
+                                            <div className="flex items-center gap-4">
+                                                <span className="text-sm font-medium text-gray-900 dark:text-white">
+                                                    ${q.amount.toLocaleString()}
+                                                </span>
 
-                {error && <p className="mt-4 text-sm text-red-500 dark:text-red-400">{error}</p>}
+                                                {!q.accepted ? (
+                                                    canManage && (
+                                                        <button
+                                                            onClick={() => handleAcceptQuote(q.quotes_id)}
+                                                            className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-600 dark:text-neutral-300 transition hover:border-green-400 hover:text-green-600 dark:hover:text-green-400"
+                                                        >
+                                                            Accept
+                                                        </button>
+                                                    )
+                                                ) : (
+                                                    <span className="text-xs font-medium text-green-600 dark:text-green-400">Accepted</span>
+                                                )}
+
+                                                {canDelete && (
+                                                    confirmingId === q.quotes_id ? (
+                                                        <div className="flex items-center gap-2">
+                                                            <button
+                                                                onClick={() => { handleDeleteQuote(q.quotes_id); setConfirmingId(null) }}
+                                                                className="rounded-xl border border-red-400/50 px-3 py-1 text-xs font-medium text-red-500 dark:text-red-400 transition hover:bg-red-50 dark:hover:bg-red-500/10"
+                                                            >
+                                                                Confirm
+                                                            </button>
+                                                            <button
+                                                                onClick={() => setConfirmingId(null)}
+                                                                className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-500 dark:text-neutral-400 transition hover:bg-gray-50 dark:hover:bg-white/[0.05]"
+                                                            >
+                                                                Cancel
+                                                            </button>
+                                                        </div>
+                                                    ) : (
+                                                        <button
+                                                            onClick={() => setConfirmingId(q.quotes_id)}
+                                                            className="rounded-xl border border-gray-200 dark:border-white/[0.12] px-3 py-1 text-xs font-medium text-gray-500 dark:text-neutral-400 transition hover:border-red-400/50 hover:text-red-500 dark:hover:text-red-400"
+                                                        >
+                                                            Delete
+                                                        </button>
+                                                    )
+                                                )}
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </section>
+                    </>
+                )}
             </div>
         </main>
     )

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -4,10 +4,15 @@ import { useRouter } from "next/navigation";
 export default function BackButton({ label = "Go Back" }: { label?: string }) {
     const router = useRouter();
 
+    function handleClick() {
+        const params = new URLSearchParams(window.location.search);
+        const orgId = params.get("orgId");
+        router.push(orgId ? `/?orgId=${orgId}` : "/");
+    }
+
     return (
         <button
-            // changed to make it visible in white mode - prabh--
-            onClick={() => router.push("/")}
+            onClick={handleClick}
             className="rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 transition hover:bg-gray-100 active:scale-95 dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white dark:hover:bg-white/[0.08]"
         >
             {label}

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -16,7 +16,6 @@ type Props = {
 
 export default function OrgDropDown({ organizations, currentOrgId, basePath }: Props) {
   // Hide entirely if user has only one org (no other orgs to switch to)
-  if (organizations.length <= 1) return null;
 
   const router = useRouter()
   const [open, setOpen] = useState(false)
@@ -48,6 +47,8 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath }: P
   useEffect(() => {
     if (open) inputRef.current?.focus()
   }, [open])
+
+  if (organizations.length <= 1) return null;
 
   const handleSelect = (orgId: string) => {
     setOpen(false)

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -10,11 +10,14 @@ type Props = {
     org_name: string
     role: string
   }[]
-    currentOrgId: string
-    basePath: string // e.g. '/dashboard' or '/files'
+  currentOrgId: string
+  basePath: string // e.g. '/dashboard' or '/files'
 }
 
 export default function OrgDropDown({ organizations, currentOrgId, basePath }: Props) {
+  // Hide entirely if user has only one org (no other orgs to switch to)
+  if (organizations.length <= 1) return null;
+
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')


### PR DESCRIPTION
## Description
Fixed six functionality issues that surfaced during DP3 testing.

---

## Issues Addressed
Closes #142 

---

## Changes
- BackButton now preserves the current `orgId` so users stay in the org they were viewing instead of being dropped back to the default org
- New organization form disables the submit button while creating to prevent duplicate org creation from spam clicks
- Quote actions (`addQuote`, `acceptQuote`, `deleteQuote`) properly check for empty result data and surface real errors when RLS blocks an operation, instead of silently faking success
- Quotes page wraps fetch in try/catch/finally so loading always completes; users without view permission now see an "Access denied" card instead of an empty interactive form
- Quote action buttons (Add, Accept, Delete) are now hidden based on role: Add and Accept for treasury_team/treasurer/admin only, Delete for treasurer/admin only
- Error banner on quotes page moved from the bottom to right below the Add Quote section, with a dismiss button
- Organization settings page expanded to allow executive and admin (in addition to treasurer and advisor) to upload org logos, matching the navbar gating and storage RLS policy
- OrgDropdown hides itself entirely when the user belongs to only one organization, since there are no other orgs to switch to
- Removed unused imports (`node:test`, `next/font/google`) and `console.log` debug statements from quotes actions

---

## How to Test
1. Pull this branch and run `npm run build && npm run start` (or test on the Vercel preview deploy)

2. **BackButton orgId preservation**: Log in as a user with multiple orgs (`treasurer@test.com`), switch to a non-default org, navigate to any sub-page, click Back. You should stay in the same org instead of falling back to the default.

3. **New org no double-submit**: Log in as a test user such as U: `d@d.d` P: `123456`, navigate to Create Organization, type a name, and submit. The button should disable after the first click and take you to the orgs page, only one org should be created.

4. **Quotes page loading and access**: Log in as `member@test.com` and visit `/quotes`. You should see an "Access denied" card instead of an empty form.

5. **Quote button gating**: Log in as each role and visit `/quotes`:
   - `member@test.com`: access denied card
   - `executive@test.com` and `advisor@test.com`: see quotes list, no Add form, no Accept/Delete buttons
   - `treasury_team@test.com`: see Add form and Accept buttons, no Delete buttons
   - `treasurer@test.com` and `admin@test.com`: see all controls

7. **Logo upload role**: Log in as `executive@test.com` or `admin@test.com`, click the org logo in the navbar, and upload a new logo. Should succeed.

8. **OrgDropdown hidden for single-org users**: Log in as `member@test.com`. The "Change Organization" dropdown should not appear anywhere in the app as they are in a single org. Log in as `multiorg@test.com` and confirm the dropdown still appears with all orgs.

---

## Screenshots

---

## Checklist
- [X] Tested locally
- [X] No errors in console