### PR TITLE
Quick hotfix for the Access Denied coming up on quotes page

### DIFF
--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -116,8 +116,8 @@ function QuotesPageContent() {
                     <BackButton />
                 </div>
 
-                {/* Access denied state */}
-                {!loading && !canView && (
+                {/* Access denied state - only show after role has been fetched */}
+                {!loading && userRole !== null && !canView && (
                     <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 text-center backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)]">
                         <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
                             Access denied
@@ -128,11 +128,11 @@ function QuotesPageContent() {
                     </section>
                 )}
 
-                {/* Main content */}
-                {(loading || canView) && (
+                {/* Main content - show during loading, while role resolves, or if user can view */}
+                {(loading || userRole === null || canView) && (
                     <>
                         {/* Add Quote Form (only for users with manage permission) */}
-                        {(loading || canManage) && (
+                        {(loading || userRole === null || canManage) && (
                             <section className="rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-6 backdrop-blur-sm shadow-[0_0_20px_rgba(255,255,255,0.05)] mb-8">
                                 <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white mb-4">Add Quote</h2>
 
@@ -179,7 +179,7 @@ function QuotesPageContent() {
                             </section>
                         )}
 
-                        {/* Error banner - moved up to be visible without scrolling */}
+                        {/* Error banner */}
                         {error && (
                             <div className="mb-8 flex items-start justify-between gap-3 rounded-xl border border-red-300 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-300">
                                 <span>{error}</span>


### PR DESCRIPTION
## Description
Fix access denied flash on quotes page for users with view permission.

---

## Issues Addressed
N/A - Came up during review of PR #144 

---

## Changes
- Updated quotes page to wait for `userRole` to resolve before deciding which UI state to render
- Access denied card now only shows after the role fetch completes (was flashing briefly for users with permission)
- Main content and Add Quote section now show loading skeletons while role is being fetched, then render the appropriate state once known

---

## How to Test
1. Pull this branch and run `npm run build` and `npm run start`, or access the vercel preview
3. Log in as `executive@test.com`, `advisor@test.com`, `treasury_team@test.com`, `treasurer@test.com`, or `admin@test.com`
4. Click the Quotes tab
5. Confirm the "Access denied" card does NOT briefly flash before the real content loads
6. Log in as `member@test.com` and confirm the "Access denied" card still shows correctly

---

## Screenshots
<!-- N/A -->

---

## Checklist
- [X] Tested locally
- [X] No errors in console