### PR TITLE
Add LightBright theme + Tasks clickable now for Navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "0.9.0",
         "@supabase/supabase-js": "2.104.1",
+        "lucide-react": "1.14.0",
         "next": "16.2.4",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -4614,7 +4615,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6004,6 +6004,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@supabase/ssr": "0.9.0",
     "@supabase/supabase-js": "2.104.1",
+    "lucide-react": "1.14.0",
     "next": "16.2.4",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,66 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   --skeleton-highlight: #374151;
 }
 
+/* GREAT WALL OF LightBright theme */
+.lightbright {
+  --background: #fff7ed;
+  --foreground: #3f2614;
+  --card: #ffffff;
+  --border: #fbdea8;
+
+  --lb-primary: #f3ab42;
+  --lb-secondary: #ffc76b;
+  --lb-soft: #fbdea8;
+  --lb-light: #ffeae3;
+  --lb-muted: #8a5a2f;
+}
+
+/* Cards */
+.lightbright .lb-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  box-shadow: 0 10px 28px rgba(243, 171, 66, 0.12);
+  transition: all 0.2s ease;
+}
+
+.lightbright .lb-card:hover {
+  background: var(--lb-light);
+  border-color: var(--lb-secondary);
+  box-shadow: 0 14px 36px rgba(243, 171, 66, 0.18);
+}
+
+/* Text */
+.lightbright .lb-text {
+  color: var(--foreground);
+}
+
+.lightbright .lb-muted {
+  color: var(--lb-muted);
+}
+
+/* Table rows */
+.lightbright .lb-row {
+  border-color: var(--border);
+}
+
+.lightbright .lb-row:hover {
+  background: #fff1e8;
+}
+
+/* Buttons */
+.lightbright .lb-button {
+  background: var(--lb-light);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+}
+
+.lightbright .lb-button:hover {
+  background: var(--lb-soft);
+  border-color: var(--lb-secondary);
+}
+
+
 @keyframes skeleton-shimmer {
     0% { background-position: 200% 0; }
     100% { background-position: -200% 0; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,8 +55,8 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
   --lb-primary: #f3ab42;
   --lb-secondary: #ffc76b;
-  --lb-soft: #fbdea8;
-  --lb-light: #ffeae3;
+  --lb-soft: #fc9d7dc2;
+  --lb-light: #fbeed15c;
   --lb-muted: #8a5a2f;
 }
 
@@ -65,14 +65,13 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   background: var(--card);
   border: 1px solid var(--border);
   color: var(--foreground);
-  box-shadow: 0 10px 28px rgba(243, 171, 66, 0.12);
   transition: all 0.2s ease;
 }
 
 .lightbright .lb-card:hover {
   background: var(--lb-light);
   border-color: var(--lb-secondary);
-  box-shadow: 0 14px 36px rgba(243, 171, 66, 0.18);
+  box-shadow: 0 14px 36px rgb(247, 213, 213);
 }
 
 /* Text */
@@ -95,14 +94,15 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Buttons */
 .lightbright .lb-button {
-  background: var(--lb-light);
-  border: 1px solid var(--border);
+  background: #ffcbb3a7;
+  border: var(--lb-secondary);
   color: var(--foreground);
 }
 
 .lightbright .lb-button:hover {
   background: var(--lb-soft);
   border-color: var(--lb-secondary);
+  color: var(--foreground);
 }
 
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 .lightbright .lb-card {
   background: var(--card);
   border: 1px solid var(--border);
-  color: var(--foreground);
+  color: var(--border);
   transition: all 0.2s ease;
 }
 
@@ -94,7 +94,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 /* Buttons */
 .lightbright .lb-button {
-  background: #ffcbb3a7;
+  background: #f4ac8ba7;
   border: var(--lb-secondary);
   color: var(--foreground);
 }
@@ -103,6 +103,20 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   background: var(--lb-soft);
   border-color: var(--lb-secondary);
   color: var(--foreground);
+}
+
+.lb-alert {
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid;
+}
+
+.lb-alert-warning {
+  background-color: #eaf2ff;
+  border-color: #5b8def;
+  color: #2a4b8d;
 }
 
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,8 +35,16 @@ const themeInitScript = `
     var saved = localStorage.getItem('treasuryhub-theme');
     var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     var theme = saved || (prefersDark ? 'dark' : 'light');
+
+    var root = document.documentElement;
+    root.classList.remove('light', 'dark', 'lightbright');
+
     if (theme === 'dark') {
       document.documentElement.classList.add('dark');
+    } else if (theme === 'lightbright') {
+      root.classList.add('lightbright');
+    } else {
+      root.classList.add('light');
     }
   } catch (e) {}
 })();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,10 +86,18 @@ function StatCard({
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
+        hover:border-gray-300
+        hover:bg-gray-50
+        hover:shadow-md
         dark:hover:border-white/[0.25]
         dark:hover:bg-white/[0.06]
         dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
-        ${hoverAccent ?? ""}
+        hover:border-gray-300
+        hover:bg-gray-50
+        hover:shadow-md
+        dark:hover:border-white/[0.25]
+        dark:hover:bg-white/[0.06]
+        dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
       `}
     >
     <div className="flex items-start justify-between gap-4 overflow-hidden">
@@ -130,6 +138,9 @@ function LinkCard({
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
+        hover:border-gray-300
+        hover:bg-gray-50
+        hover:shadow-md
         dark:hover:border-white/[0.25]
         dark:hover:bg-white/[0.06]
         dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
@@ -162,9 +173,10 @@ function QuotesCard({ orgId }: { orgId: string }) {
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
-        hover:border-white/[0.25]
-        hover:bg-white/[0.06]
-        hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
+        hover:bg-gray-50 hover:border-gray-300
+        dark:hover:border-white/[0.25]
+        dark:hover:bg-white/[0.06]
+        dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
       "
     >
       <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
@@ -219,6 +231,7 @@ function TransactionsTable({
           <Link
             href={`/transaction?orgId=${orgId}`}
             className="
+              lb-button
               rounded-xl
               border border-white/[0.2]
               bg-white/[0.05]
@@ -226,7 +239,7 @@ function TransactionsTable({
               text-sm font-medium text-gray-900 dark:text-white
               transition
               hover:border-white/[0.35]
-              hover:bg-white/[0.08]
+              hover:bg-gray-100 dark:hover:bg-white/[0.08]
             "
           >
             View Transactions
@@ -244,7 +257,7 @@ function TransactionsTable({
                 text-sm font-medium text-gray-900 dark:text-white
                 transition
                 hover:border-white/[0.35]
-                hover:bg-blue-100/[0.08]
+                hover:bg-gray-100 dark:hover:bg-white/[0.08]
               "
             />
           )}
@@ -271,7 +284,7 @@ function TransactionsTable({
                   lb-row
                   border-b border-white/[0.12]
                   transition
-                  hover:bg-white/[0.05]
+                  hover:bg-gray-50 dark:hover:bg-white/[0.05]
                 "
               >
                 <td className="py-4 pr-6  text-gray-900 dark:text-white">
@@ -553,21 +566,21 @@ export default async function DashboardPage({
                 value={formatCurrency(data.summary.income)}
                 icon={<DollarSign className="h-5 w-5" />}
                 accent="bg-green-100 text-green-600"
-                hoverAccent="dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
+                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Expenses"
                 value={formatCurrency(data.summary.expenses)}
                 icon={<TrendingDown className="h-5 w-5" />}
                 accent="bg-rose-100 text-rose-600"
-                hoverAccent="dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
+                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard 
                 label="Net" 
                 value={formatCurrency(data.summary.net)} 
                 icon={<Wallet className="h-5 w-5" />}
                 accent="bg-violet-100 text-violet-600"
-                hoverAccent="dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
+                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
               />
 
               <LinkCard

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,16 @@ import { canExportTransactions, canViewFiles } from "@/lib/roles";
 import Navbar from "@/components/Navbar";
 import { getTasks } from "@/app/tasks/actions";
 import TaskRoleFilter from "@/components/TaskRoleFilter";
+import {
+  DollarSign,
+  TrendingDown,
+  Wallet,
+  ReceiptText,
+  ShieldCheck,
+  FileText,
+  ClipboardList,
+  Upload,
+} from "lucide-react";
 
 export const metadata: Metadata = {
   title: {
@@ -55,13 +65,20 @@ function formatCurrency(value: number) {
 function StatCard({
   label,
   value,
+  icon,
+  accent,
+  hoverAccent,
 }: {
   label: string;
   value: string | number;
+  icon: React.ReactNode;
+  accent: string;
+  hoverAccent?: string;
 }) {
   return (
     <div //chnaged for layout -prabh
-      className="
+      className= {`
+        lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12] 
         bg-white dark:bg-white/[0.03]
@@ -69,17 +86,22 @@ function StatCard({
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
-        hover:border-white/[0.25]
-        hover:bg-white/[0.06]
-        hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
-      "
+        dark:hover:border-white/[0.25]
+        dark:hover:bg-white/[0.06]
+        dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
+        ${hoverAccent ?? ""}
+      `}
     >
-      <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
-        {label}
-      </p>
-      <p className="mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
-        {value}
-      </p>
+    <div className="flex items-start justify-between gap-4 overflow-hidden">
+        <div>
+          <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
+            {label}
+          </p>
+          <p className="lb-text mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
+            {value}
+          </p>
+        </div>
+      </div>
     </div>
   );
 }
@@ -99,6 +121,7 @@ function LinkCard({
     <Link
       href={href} //changed for layout -prabh
       className=" 
+        lb-card
         group
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
@@ -107,15 +130,15 @@ function LinkCard({
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
-        hover:border-white/[0.25]
-        hover:bg-white/[0.06]
-        hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
+        dark:hover:border-white/[0.25]
+        dark:hover:bg-white/[0.06]
+        dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
       "
     >
-      <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
+      <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
         {label}
       </p>
-      <p className="mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
+      <p className="lb-text mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
         {title}
       </p>
       <p className="mt-2 text-sm text-gray-600 dark:text-neutral-300 transition group-hover:text-gray-900 dark:group-hover:text-white">
@@ -130,6 +153,7 @@ function QuotesCard({ orgId }: { orgId: string }) {
     <Link 
       href={`/quotes?orgId=${orgId}`} //changed for layout- prabh
       className="
+        lb-card
         group
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
@@ -143,10 +167,10 @@ function QuotesCard({ orgId }: { orgId: string }) {
         hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
       "
     >
-      <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
+      <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
         Quotes
       </p>
-      <p className="mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
+      <p className="lb-muted mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
         Open
       </p>
       <p className="mt-2 text-sm text-gray-600 dark:text-neutral-300 transition group-hover:text-gray-900 dark:group-hover:text-white">
@@ -177,6 +201,7 @@ function TransactionsTable({
   return (
     <section //changed for layout -prabh
       className="
+        lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
         bg-white dark:bg-white/[0.03]
@@ -211,6 +236,7 @@ function TransactionsTable({
             <ExportCSVButton
               orgId={orgId}
               className="
+                lb-button
                 rounded-xl
                 border border-white/[0.2]
                 bg-blue-500/[0.05]
@@ -242,6 +268,7 @@ function TransactionsTable({
               <tr
                 key={tx.transaction_id}
                 className="
+                  lb-row
                   border-b border-white/[0.12]
                   transition
                   hover:bg-white/[0.05]
@@ -283,6 +310,7 @@ function TasksSection({
   return (
     <section //changed for layout - prabh
       className="
+        lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
       bg-white dark:bg-white/[0.03]
@@ -393,12 +421,13 @@ bg-white dark:bg-white/[0.03]
               <button
                 type="submit"
                 className="
-            inline-flex items-center rounded-xl
-            border border-gray-300 dark:border-white/[0.2]
-           bg-white dark:bg-white/[0.05]
-            px-5 py-3 text-sm font-medium text-gray-900 dark:text-white transition
-           hover:bg-gray-100 dark:hover:bg-white/[0.1]
-          "
+                lb-button
+                inline-flex items-center rounded-xl
+              border border-gray-300 dark:border-white/[0.2]
+              bg-white dark:bg-white/[0.05]
+              px-5 py-3 text-sm font-medium text-gray-900 dark:text-white transition
+              hover:bg-gray-100 dark:hover:bg-white/[0.1]
+            "
               >
                 Sign Out
               </button>
@@ -407,6 +436,7 @@ bg-white dark:bg-white/[0.03]
             <Link
               href="/organizations"
               className="
+                lb-button
                 inline-flex items-center rounded-xl
                 border border-blue-500
                bg-blue-500
@@ -498,7 +528,7 @@ export default async function DashboardPage({
   const canExport = canExportTransactions(data.role);
 
   return ( //changed for layout - prabh
-    <main className="min-h-screen bg-background text-foreground">
+    <main className="lb-page min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       <Navbar
           currentUserRole={data.role}
           organizations={data.organizations}
@@ -521,12 +551,24 @@ export default async function DashboardPage({
               <StatCard
                 label="Income"
                 value={formatCurrency(data.summary.income)}
+                icon={<DollarSign className="h-5 w-5" />}
+                accent="bg-green-100 text-green-600"
+                hoverAccent="dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Expenses"
                 value={formatCurrency(data.summary.expenses)}
+                icon={<TrendingDown className="h-5 w-5" />}
+                accent="bg-rose-100 text-rose-600"
+                hoverAccent="dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
               />
-              <StatCard label="Net" value={formatCurrency(data.summary.net)} />
+              <StatCard 
+                label="Net" 
+                value={formatCurrency(data.summary.net)} 
+                icon={<Wallet className="h-5 w-5" />}
+                accent="bg-violet-100 text-violet-600"
+                hoverAccent="dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
+              />
 
               <LinkCard
                 href={`/transaction?orgId=${data.orgId}`}
@@ -574,22 +616,37 @@ export default async function DashboardPage({
               <StatCard
                 label="Reimbursements"
                 value={formatCurrency(data.summary.reimbursementsTotal)}
+                icon={<DollarSign className="h-5 w-5" />}
+                accent="bg-emerald-100 text-emerald-600"
+                hoverAccent="dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Payables"
                 value={formatCurrency(data.summary.payablesTotal)}
+                icon={<TrendingDown className="h-5 w-5" />}
+                accent="bg-rose-100 text-rose-600"
+                hoverAccent="dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Receivables"
                 value={formatCurrency(data.summary.receivablesTotal)}
+                icon={<Wallet className="h-5 w-5" />}
+                accent="bg-violet-100 text-violet-600"
+                hoverAccent="dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Transactions"
                 value={data.summary.personalTransactionCount}
+                icon={<ReceiptText className="h-5 w-5" />}
+                accent="bg-blue-100 text-blue-600"
+                hoverAccent="dark:hover:bg-blue-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Uploaded Files"
                 value={data.summary.uploadedFilesCount}
+                icon={<Upload className="h-5 w-5" />}
+                accent="bg-sky-100 text-sky-600"
+                hoverAccent="dark:hover:bg-sky-50 dark:hover:bg-white/[0.06]"
               />
             </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,9 +138,9 @@ function LinkCard({
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
-        hover:border-gray-300
-        hover:bg-gray-50
-        hover:shadow-md
+        hover:border-[#F3AB42]/40
+        hover:bg-[#FFF6DB]
+        hover:shadow-[0_0_20px_rgba(243,171,66,0.18)]
         dark:hover:border-white/[0.25]
         dark:hover:bg-white/[0.06]
         dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
@@ -173,7 +173,9 @@ function QuotesCard({ orgId }: { orgId: string }) {
         backdrop-blur-sm
         transition duration-300
         shadow-[0_0_20px_rgba(255,255,255,0.05)]
-        hover:bg-gray-50 hover:border-gray-300
+        hover:border-[#F3AB42]/40
+        hover:bg-[#FFF6DB]
+        hover:shadow-[0_0_20px_rgba(243,171,66,0.18)]
         dark:hover:border-white/[0.25]
         dark:hover:bg-white/[0.06]
         dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
@@ -182,7 +184,7 @@ function QuotesCard({ orgId }: { orgId: string }) {
       <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
         Quotes
       </p>
-      <p className="lb-muted mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
+      <p className="mt-3 text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">
         Open
       </p>
       <p className="mt-2 text-sm text-gray-600 dark:text-neutral-300 transition group-hover:text-gray-900 dark:group-hover:text-white">
@@ -213,7 +215,6 @@ function TransactionsTable({
   return (
     <section //changed for layout -prabh
       className="
-        lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
         bg-white dark:bg-white/[0.03]
@@ -323,7 +324,6 @@ function TasksSection({
   return (
     <section //changed for layout - prabh
       className="
-        lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12]
       bg-white dark:bg-white/[0.03]
@@ -354,6 +354,7 @@ function TasksSection({
   <Link
     href={`/tasks?orgId=${orgId}`}
     className="
+      lb-button
       rounded-xl
       border border-white/[0.2]
       bg-white/[0.05]
@@ -376,28 +377,37 @@ function TasksSection({
           </div>
         ) : (
           tasks.map((task) => (
-            <div
+            <Link
               key={task.id}
-              className="
-                rounded-xl border border-gray-200 bg-gray-50 px-4 py-3
-                dark:border-white/[0.12] dark:bg-white/[0.03]
-              "
+              href={`/tasks?orgId=${orgId}`}
+              className="block rounded-xl"
             >
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-medium text-gray-900 dark:text-white">
-                    {task.title}
-                  </p>
-                  <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
-                    Assigned to {task.assigned_to} • {task.task_type}
+              <div
+                className="
+                  lb-row
+                  rounded-xl border border-gray-200 bg-gray-50 px-4 py-3
+                  transition
+                  hover:bg-gray-100
+                  dark:border-white/[0.12] dark:bg-white/[0.03]
+                  dark:hover:bg-white/[0.08]
+                "
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {task.title}
+                    </p>
+                    <p className="mt-1 text-xs text-gray-500 dark:text-neutral-400">
+                      Assigned to {task.assigned_to} • {task.task_type}
+                    </p>
+                  </div>
+
+                  <p className="text-sm text-gray-600 dark:text-neutral-300">
+                    Due {formatDateOnly(task.due_date)}
                   </p>
                 </div>
-
-                <p className="text-sm text-gray-600 dark:text-neutral-300">
-                  Due {formatDateOnly(task.due_date)}
-                </p>
               </div>
-            </div>
+            </Link>
           ))
         )}
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,15 +65,9 @@ function formatCurrency(value: number) {
 function StatCard({
   label,
   value,
-  icon,
-  accent,
-  hoverAccent,
 }: {
   label: string;
   value: string | number;
-  icon: React.ReactNode;
-  accent: string;
-  hoverAccent?: string;
 }) {
   return (
     <div //chnaged for layout -prabh
@@ -574,23 +568,14 @@ export default async function DashboardPage({
               <StatCard
                 label="Income"
                 value={formatCurrency(data.summary.income)}
-                icon={<DollarSign className="h-5 w-5" />}
-                accent="bg-green-100 text-green-600"
-                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Expenses"
                 value={formatCurrency(data.summary.expenses)}
-                icon={<TrendingDown className="h-5 w-5" />}
-                accent="bg-rose-100 text-rose-600"
-                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard 
                 label="Net" 
                 value={formatCurrency(data.summary.net)} 
-                icon={<Wallet className="h-5 w-5" />}
-                accent="bg-violet-100 text-violet-600"
-                hoverAccent="hover:bg-gray-50 hover:border-gray-300 dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
               />
 
               <LinkCard
@@ -639,37 +624,22 @@ export default async function DashboardPage({
               <StatCard
                 label="Reimbursements"
                 value={formatCurrency(data.summary.reimbursementsTotal)}
-                icon={<DollarSign className="h-5 w-5" />}
-                accent="bg-emerald-100 text-emerald-600"
-                hoverAccent="dark:hover:bg-emerald-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Payables"
                 value={formatCurrency(data.summary.payablesTotal)}
-                icon={<TrendingDown className="h-5 w-5" />}
-                accent="bg-rose-100 text-rose-600"
-                hoverAccent="dark:hover:bg-rose-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Receivables"
                 value={formatCurrency(data.summary.receivablesTotal)}
-                icon={<Wallet className="h-5 w-5" />}
-                accent="bg-violet-100 text-violet-600"
-                hoverAccent="dark:hover:bg-violet-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Transactions"
                 value={data.summary.personalTransactionCount}
-                icon={<ReceiptText className="h-5 w-5" />}
-                accent="bg-blue-100 text-blue-600"
-                hoverAccent="dark:hover:bg-blue-50 dark:hover:bg-white/[0.06]"
               />
               <StatCard
                 label="Uploaded Files"
                 value={data.summary.uploadedFilesCount}
-                icon={<Upload className="h-5 w-5" />}
-                accent="bg-sky-100 text-sky-600"
-                hoverAccent="dark:hover:bg-sky-50 dark:hover:bg-white/[0.06]"
               />
             </section>
 

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -209,11 +209,11 @@ function TasksPageContent() {
 
         {/* Upcoming alerts banner */}
         {getNotifications(tasks).length > 0 && (
-          <div className="mb-6 rounded-2xl border border-yellow-200 dark:border-yellow-500/30 bg-yellow-50 dark:bg-yellow-500/10 px-5 py-4">
-            <p className="text-sm font-semibold text-yellow-800 dark:text-yellow-300 mb-2">Upcoming Task Alerts</p>
+          <div className="lb-alert lb-alert-warning mb-6 rounded-2xl border border-yellow-200 dark:border-yellow-500/30 bg-yellow-50 dark:bg-yellow-500/10 px-5 py-4">
+            <p className="lb-alert-warning text-sm font-semibold text-yellow-800 dark:text-yellow-300 mb-2">Upcoming Task Alerts</p>
             <ul className="space-y-1">
               {getNotifications(tasks).map((task) => (
-                <li key={task.id} className="text-sm text-yellow-700 dark:text-yellow-400">
+                <li key={task.id} className="lb-alert-warning text-sm text-yellow-700 dark:text-yellow-400">
                   {task.title} is due on {task.dueDate}
                 </li>
               ))}

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -61,6 +61,7 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath }: P
       <button
         onClick={() => setOpen((prev) => !prev)}
         className="
+          lb-button
           font-[var(--font-geist-sans)]
           cursor-pointer rounded-lg
           border border-white/[0.15]

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 
-type Theme = "light" | "dark"
+type Theme = "light" | "dark" | "lightbright"
 
 const STORAGE_KEY = "treasuryhub-theme"
 
@@ -11,16 +11,20 @@ const STORAGE_KEY = "treasuryhub-theme"
 // has already applied the correct theme before this component mounts.
 function getCurrentTheme(): Theme {
     if (typeof document === "undefined") return "light"
-    return document.documentElement.classList.contains("dark") ? "dark" : "light"
+    const root = document.documentElement
+
+    if (root.classList.contains("dark")) return "dark"
+    if (root.classList.contains("lightbright")) return "lightbright"
+
+    return "light"
 }
 
 function applyTheme(theme: Theme) {
     const root = document.documentElement
-    if (theme === "dark") {
-        root.classList.add("dark")
-    } else {
-        root.classList.remove("dark")
-    }
+    
+    root.classList.remove("light", "dark", "lightbright")
+    root.classList.add(theme)
+
     try {
         localStorage.setItem(STORAGE_KEY, theme)
     } catch {
@@ -38,20 +42,29 @@ export default function ThemeToggle() {
         setTheme(getCurrentTheme())
     }, [])
 
-    function toggle() {
-        const next: Theme = theme === "dark" ? "light" : "dark"
+    function setSelectedTheme(next: Theme) {
         applyTheme(next)
         setTheme(next)
     }
 
     return (
+        <div className="flex rounded-xl border border-[var(--border)] bg-[var(--card)] p-1 shadow-sm">
+      {(["light", "lightbright", "dark"] as Theme[]).map((option) => (
         <button
-            type="button"
-            onClick={toggle}
-            aria-label="Toggle theme"
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-black hover:bg-gray-100 dark:border-white/[0.15] dark:bg-white/[0.05] dark:text-white dark:hover:bg-white/[0.08]"
+          key={option}
+          type="button"
+          onClick={() => setSelectedTheme(option)}
+          className={`rounded-lg px-3 py-1.5 text-sm font-medium transition ${
+            theme === option
+              ? "bg-amber-100 text-amber-700"
+              : "text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-white/[0.08]"
+          }`}
         >
-            {theme === null ? "..." : theme === "dark" ? "Switch to light" : "Switch to dark"}
+          {option === "lightbright"
+            ? "LightBright"
+            : option.charAt(0).toUpperCase() + option.slice(1)}
         </button>
+      ))}
+    </div>
     )
 }


### PR DESCRIPTION
## Description
Adds a LightBright theme and improves dashboard styling consistency.

---

## Issues Addressed
* Addresses issue #146 

---

## Changes
- Added LightBright theme with custom color palette
- Updated StatCards to support themed hover styling
- Standardized card styling across dashboard components
- Added icon support structure for StatCards
- Installed lucide-react for future icon usage

---

## How to Test
1. Pull this branch and run `npm install`
2. Start the app with `npm run dev`
3. Go to Settings → switch to LightBright theme
4. Verify dashboard cards have correct hover behavior and styling

---

## Screenshots
New Button in Settings
<img width="672" height="775" alt="Screenshot 2026-05-01 at 1 42 08 PM" src="https://github.com/user-attachments/assets/98f49f76-3214-4803-8a19-405079167d19" />

Theme Change in Settings
<img width="795" height="776" alt="Screenshot 2026-05-01 at 1 42 17 PM" src="https://github.com/user-attachments/assets/67e01576-6f46-49a1-ad08-0b37ba9af9b6" />

Theme change in Dashboard, hovering over Quotes
<img width="1501" height="889" alt="Screenshot 2026-05-01 at 1 42 31 PM" src="https://github.com/user-attachments/assets/1748fc7b-1f4d-4c64-8056-cc0e4d50e4c4" />

---
## Note
* Icons for the cards are not yet displayed
* It's not fully implemented and just the backbone for a new theme
* Some classes in elements not properly defined or standardized, so global css for the new theme is not accurate yet

---

## Checklist
- [x] Tested locally
- [x] No errors in console