### PR TITLE
Fix all final bugs found before presentation/competition

### DIFF
--- a/src/app/auth/signout/route.ts
+++ b/src/app/auth/signout/route.ts
@@ -7,6 +7,6 @@ export async function POST(request: Request) {
 
    await supabase.auth.signOut();
 
-   return NextResponse.redirect(new URL("/login", request.url));
+   return NextResponse.redirect(new URL("/login", request.url), { status: 303 });
 
 }

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -2,21 +2,21 @@
 
 // base function used by all other skeleton components
 function SkeletonPulse({ className = "" }: { className?: string }) {
-    return(
+    return (
         <div
-            className={`animate-pulse rounded-md bg-white/[0.07] ${className}`}
+            className={`animate-pulse rounded-md bg-gray-200 dark:bg-white/[0.07] ${className}`}
         />
     );
 }
 
 // StatCardSkeleton - placeholder for the <StatCard> component
-function StatCardSkeleton(){
-    return(
+function StatCardSkeleton() {
+    return (
         <div
             className="
-                rounded-2x1
-                border border-white/[0.12]
-                bg-white/[0.03]
+                rounded-2xl
+                border border-gray-200 dark:border-white/[0.12]
+                bg-white dark:bg-white/[0.03]
                 p-5
                 backdrop-blur-sm
                 shadow-[0_0_20px_rgba(255,255,255,0.05)]
@@ -29,13 +29,13 @@ function StatCardSkeleton(){
 }
 
 // LinkCardSkeleton - placeholder for the <LinkCard> and <QuotesCard>
-function LinkCardSkeleton(){
-    return(
+function LinkCardSkeleton() {
+    return (
         <div
             className="
-                rounded-2x1
-                border border-white/[0.12]
-                bg-white/[0.03]
+                rounded-2xl
+                border border-gray-200 dark:border-white/[0.12]
+                bg-white dark:bg-white/[0.03]
                 p-5
                 backdrop-blur-sm
                 shadow-[0_0_20px_rgba(255,255,255,0.05)]
@@ -49,20 +49,20 @@ function LinkCardSkeleton(){
 }
 
 // TransactionsTableSkeleton - placeholder for the <TransactionsTable>
-function TransactionsTableSkeleton({ title }: { title: string }){
-    return(
+function TransactionsTableSkeleton({ title }: { title: string }) {
+    return (
         <section
             className="
-                rounded-2x1
-                border border-white/[0.12]
-                bg-white/[0.03]
+                rounded-2xl
+                border border-gray-200 dark:border-white/[0.12]
+                bg-white dark:bg-white/[0.03]
                 p-6
                 backdrop-blur-sm
-                shadow-[0_0_20px_rgba(255.255,255,0.05)]
+                shadow-[0_0_20px_rgba(255,255,255,0.05)]
             "
         >
             <div className="mb-6 flex items-center justify-between gap-4">
-                <h2 className="text-lg font-semibold tracking-tight text-white">
+                <h2 className="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">
                     {title}
                 </h2>
                 <div className="flex flex-wrap items-center gap-3">
@@ -74,12 +74,12 @@ function TransactionsTableSkeleton({ title }: { title: string }){
             <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
                     <thead>
-                        <tr className="border-b border-white/[0.2]">
+                        <tr className="border-b border-gray-200 dark:border-white/[0.2]">
                             {["Date", "Description", "Category", "Type", "Amount"].map(
                                 (col) => (
                                     <th
                                         key={col}
-                                        className="py-3 pr-6 text-left text-xs uppercase tracking-[0.16em] text-neutral-500 font-medium last:text-right last:pr-0"
+                                        className="py-3 pr-6 text-left text-xs uppercase tracking-[0.16em] text-gray-500 dark:text-neutral-500 font-medium last:text-right last:pr-0"
                                     >
                                         {col}
                                     </th>
@@ -87,12 +87,12 @@ function TransactionsTableSkeleton({ title }: { title: string }){
                             )}
                         </tr>
                     </thead>
-                    
+
                     <tbody>
                         {Array.from({ length: 6 }).map((_, i) => (
                             <tr
                                 key={i}
-                                className="border-b border-white/[0.08]"
+                                className="border-b border-gray-100 dark:border-white/[0.08]"
                             >
                                 <td className="py-4 pr-6">
                                     <SkeletonPulse className="h-4 w-20" />
@@ -119,13 +119,13 @@ function TransactionsTableSkeleton({ title }: { title: string }){
 }
 
 // TasksSectionSkeleton - placeholder for the <TasksSection> component
-function TasksSectionSkeleton(){
-    return(
+function TasksSectionSkeleton() {
+    return (
         <section
             className="
-                rounded-2x1
-                border border-white/[0.12]
-                bg-white/[0.03]
+                rounded-2xl
+                border border-gray-200 dark:border-white/[0.12]
+                bg-white dark:bg-white/[0.03]
                 p-6
                 backdrop-blur-sm
                 shadow-[0_0_20px_rgba(255,255,255,0.05)]
@@ -139,7 +139,7 @@ function TasksSectionSkeleton(){
                 <SkeletonPulse className="h-9 w-28 rounded-xl" />
             </div>
 
-            <div className="rounded-xl border border-dashed border-white/[0.12] px-4 py-6">
+            <div className="rounded-xl border border-dashed border-gray-200 dark:border-white/[0.12] px-4 py-6">
                 <SkeletonPulse className="h-4 w-72 mx-auto" />
             </div>
         </section>
@@ -147,8 +147,8 @@ function TasksSectionSkeleton(){
 }
 
 // NavbarSkeleton - placeholder for the <Navbar> component
-function NavbarSkeleton(){
-    return(
+function NavbarSkeleton() {
+    return (
         <div className="mb-8 flex items-center justify-between">
             <div className="flex items-center gap-3">
                 <SkeletonPulse className="h-8 w-8 rounded-lg" />
@@ -166,28 +166,28 @@ function NavbarSkeleton(){
 
 // DashboardLoading - the default export by Next.js as the Suspense
 export default function DashboardLoading() {
-  return (
-    <main className="min-h-screen bg-black text-white">
-      <div className="mx-auto max-w-7xl px-6 py-8 lg:px-8">
-        <NavbarSkeleton />
- 
-        <div className="space-y-8">
-          {/* Stat + link cards — matches the 7-column org layout (widest case) */}
-          <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-7">
-            <StatCardSkeleton />
-            <StatCardSkeleton />
-            <StatCardSkeleton />
-            <StatCardSkeleton />
-            <LinkCardSkeleton />
-            <LinkCardSkeleton />
-            <LinkCardSkeleton />
-          </section>
- 
-          <TransactionsTableSkeleton title="Recent Organization Transactions" />
- 
-          <TasksSectionSkeleton />
-        </div>
-      </div>
-    </main>
-  );
+    return (
+        <main className="min-h-screen bg-background text-foreground">
+            <div className="mx-auto max-w-7xl px-6 py-8 lg:px-8">
+                <NavbarSkeleton />
+
+                <div className="space-y-8">
+                    {/* Stat + link cards — matches the 7-column org layout (widest case) */}
+                    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-7">
+                        <StatCardSkeleton />
+                        <StatCardSkeleton />
+                        <StatCardSkeleton />
+                        <StatCardSkeleton />
+                        <LinkCardSkeleton />
+                        <LinkCardSkeleton />
+                        <LinkCardSkeleton />
+                    </section>
+
+                    <TransactionsTableSkeleton title="Recent Organization Transactions" />
+
+                    <TasksSectionSkeleton />
+                </div>
+            </div>
+        </main>
+    );
 }

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -61,7 +61,7 @@ export default function ForgotPasswordPage() {
                     Reset your password
                 </h1>
                 <p className="text-sm text-gray-500 dark:text-neutral-400 mb-6">
-                    Enter your account email and we'll send you a link to reset your password.
+                    Enter your account email and we&apos;ll send you a link to reset your password.
                 </p>
 
                 <div className="flex flex-col gap-3">

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -34,45 +34,56 @@ export default function ForgotPasswordPage() {
 
     if (success) {
         return (
-            <div className="mt-10 flex flex-col items-center gap-4">
-                <p className="text-green-500 text-center max-w-md">
-                    If that email is registered, a password reset link has been sent.
-                    Check your inbox.
-                </p>
-                <BackButton label="Back to Login" />
-            </div>
+            <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
+                <section className="w-full max-w-sm rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 shadow-[0_0_20px_rgba(255,255,255,0.05)] backdrop-blur-sm text-center">
+                    <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400 mb-1">
+                        TreasuryHub
+                    </p>
+                    <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white mb-4">
+                        Check your inbox
+                    </h1>
+                    <p className="text-sm text-gray-500 dark:text-neutral-400 mb-6">
+                        If that email is registered, a password reset link has been sent.
+                    </p>
+                    <BackButton label="Back to Login" />
+                </section>
+            </main>
         )
     }
 
     return (
-        <div>
-            <div className="mt-5 flex flex-col items-center justify-center gap-3">
-                <h1 className="text-xl font-semibold mb-2">Reset your password</h1>
-                <p className="text-sm text-neutral-400 max-w-sm text-center mb-2">
-                    Enter your account email and we&apos;ll send you a link to reset your password.
+        <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
+            <section className="w-full max-w-sm rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 shadow-[0_0_20px_rgba(255,255,255,0.05)] backdrop-blur-sm">
+                <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400 mb-1">
+                    TreasuryHub
+                </p>
+                <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white mb-2">
+                    Reset your password
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-neutral-400 mb-6">
+                    Enter your account email and we'll send you a link to reset your password.
                 </p>
 
-                <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
-                    placeholder="Email"
-                />
-
-                <div className="flex gap-2">
+                <div className="flex flex-col gap-3">
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Email"
+                    />
                     <button
                         onClick={handleSubmit}
                         disabled={loading}
-                        className="border border-gray-300 rounded p-2 text-gray-900 hover:bg-gray-100 disabled:opacity-50 dark:border-white/[0.2] dark:text-white dark:hover:bg-white/[0.1]"
+                        className="w-full rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20 disabled:opacity-50"
                     >
                         {loading ? "Sending..." : "Send reset link"}
                     </button>
                     <BackButton label="Cancel" />
                 </div>
 
-                {error && <p className="text-red-500 text-sm">{error}</p>}
-            </div>
-        </div>
+                {error && <p className="mt-3 text-sm text-red-500 dark:text-red-400">{error}</p>}
+            </section>
+        </main>
     )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,19 +121,22 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 
 @keyframes skeleton-shimmer {
-    0% { background-position: 200% 0; }
-    100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .skeleton {
   display: block;
   background-color: var(--skeleton-base);
-  background-image: linear-gradient(
-    90deg,
-    var(--skeleton-base) 25%,
-    var(--skeleton-highlight) 50%,
-    var(--skeleton-base) 75%
-  );
+  background-image: linear-gradient(90deg,
+      var(--skeleton-base) 25%,
+      var(--skeleton-highlight) 50%,
+      var(--skeleton-base) 75%);
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.5s infinite linear;
 }
@@ -143,5 +146,5 @@ dialog {
 }
 
 :where(.dark, .dark *) dialog {
-  background-color: rgba(255, 255, 255, 0);
+  background-color: #0a0a0a;
 }

--- a/src/app/organizations/[orgId]/members/page.tsx
+++ b/src/app/organizations/[orgId]/members/page.tsx
@@ -110,14 +110,14 @@ export default async function OrganizationMembersPage({
 
         {/* Org Logo */}
         <div className="flex flex-col items-center justify-center gap-3 text-center mb-8">
-          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-full border border-gray-200 dark:border-white/[0.12] bg-gray-50 dark:bg-white/[0.03] sm:h-28 sm:w-28 md:h-32 md:w-32">
+          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-gray-50 dark:bg-white/[0.03] sm:h-28 sm:w-28 md:h-32 md:w-32">
             {signedLogoUrl ? (
               <Image
                 src={signedLogoUrl}
                 alt={`${organization.org_name} logo`}
                 width={128}
                 height={128}
-                className="h-full w-full object-cover"
+                className="h-full w-full object-contain"
               />
             ) : (
               <span className="text-2xl font-semibold text-gray-900 dark:text-white md:text-3xl">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -247,7 +247,7 @@ function TransactionsTable({
                 lb-button
                 rounded-xl
                 border border-gray-200 dark:border-white/[0.2]
-                bg-blue-50 dark:bg-blue-500/[0.05]
+                bg-white dark:bg-white/[0.05]
                 px-4 py-2
                 text-sm font-medium text-gray-900 dark:text-white
                 transition

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,7 +71,7 @@ function StatCard({
 }) {
   return (
     <div //chnaged for layout -prabh
-      className= {`
+      className={`
         lb-card
         rounded-2xl
         border border-gray-200 dark:border-white/[0.12] 
@@ -94,7 +94,7 @@ function StatCard({
         dark:hover:shadow-[0_0_35px_rgba(255,255,255,0.12)]
       `}
     >
-    <div className="flex items-start justify-between gap-4 overflow-hidden">
+      <div className="flex items-start justify-between gap-4 overflow-hidden">
         <div>
           <p className="lb-muted text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400">
             {label}
@@ -155,7 +155,7 @@ function LinkCard({
 
 function QuotesCard({ orgId }: { orgId: string }) {
   return (
-    <Link 
+    <Link
       href={`/quotes?orgId=${orgId}`} //changed for layout- prabh
       className="
         lb-card
@@ -228,12 +228,12 @@ function TransactionsTable({
             className="
               lb-button
               rounded-xl
-              border border-white/[0.2]
-              bg-white/[0.05]
+              border border-gray-200 dark:border-white/[0.2]
+              bg-white dark:bg-white/[0.05]
               px-4 py-2
               text-sm font-medium text-gray-900 dark:text-white
               transition
-              hover:border-white/[0.35]
+              hover:border-gray-300 dark:hover:border-white/[0.35]
               hover:bg-gray-100 dark:hover:bg-white/[0.08]
             "
           >
@@ -246,12 +246,12 @@ function TransactionsTable({
               className="
                 lb-button
                 rounded-xl
-                border border-white/[0.2]
-                bg-blue-500/[0.05]
+                border border-gray-200 dark:border-white/[0.2]
+                bg-blue-50 dark:bg-blue-500/[0.05]
                 px-4 py-2
                 text-sm font-medium text-gray-900 dark:text-white
                 transition
-                hover:border-white/[0.35]
+                hover:border-gray-300 dark:hover:border-white/[0.35]
                 hover:bg-gray-100 dark:hover:bg-white/[0.08]
               "
             />
@@ -332,36 +332,36 @@ function TasksSection({
             Tasks
           </h2>
           <p className="mt-1 text-sm text-gray-500 dark:text-neutral-400">
-           Upcoming tasks due soon. View and manage assignments.
+            Upcoming tasks due soon. View and manage assignments.
           </p>
         </div>
         <div className="flex items-center gap-2">
-  {canSeeAllTasks && roleOptions.length > 0 && (
-    <TaskRoleFilter
-      orgId={orgId}
-      roleOptions={roleOptions}
-      selectedRole={selectedRole}
-    />
+          {canSeeAllTasks && roleOptions.length > 0 && (
+            <TaskRoleFilter
+              orgId={orgId}
+              roleOptions={roleOptions}
+              selectedRole={selectedRole}
+            />
 
-  )}
+          )}
 
-  <Link
-    href={`/tasks?orgId=${orgId}`}
-    className="
-      lb-button
-      rounded-xl
-      border border-white/[0.2]
-      bg-white/[0.05]
-      px-4 py-2
-      text-sm font-medium text-gray-900 dark:text-white
-      transition
-      hover:border-white/[0.35]
-      hover:bg-white/[0.08]
-    "
-  >
-    Open Tasks
-  </Link>
-</div>
+          <Link
+            href={`/tasks?orgId=${orgId}`}
+            className="
+              lb-button
+              rounded-xl
+              border border-gray-200 dark:border-white/[0.2]
+              bg-white dark:bg-white/[0.05]
+              px-4 py-2
+              text-sm font-medium text-gray-900 dark:text-white
+              transition
+              hover:border-gray-300 dark:hover:border-white/[0.35]
+              hover:bg-gray-100 dark:hover:bg-white/[0.08]
+            "
+          >
+            Open Tasks
+          </Link>
+        </div>
       </div>
 
       <div className="space-y-3">
@@ -411,7 +411,7 @@ function TasksSection({
 
 function NoOrganizationState() {
   return ( //changed for layout - prabh
-    <main className="min-h-screen bg-background text-foreground"> 
+    <main className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 py-12">
         <section
           className="
@@ -474,7 +474,7 @@ bg-white dark:bg-white/[0.03]
 export default async function DashboardPage({
   searchParams,
 }: DashboardPageProps) {
-  const { orgId, taskRole = "all"} = await searchParams;
+  const { orgId, taskRole = "all" } = await searchParams;
 
   let data: Awaited<ReturnType<typeof getDashboardData>> | null = null;
 
@@ -490,73 +490,73 @@ export default async function DashboardPage({
 
   const currentOrg =
     data.organizations.find((org) => org.org_id === data.orgId) || null;
-    const tasksResult = await getTasks(data.orgId);
+  const tasksResult = await getTasks(data.orgId);
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    
-    const twoWeeksFromNow = new Date(today);
-    twoWeeksFromNow.setDate(today.getDate() + 14);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
-    const canSeeAllTasks = ["treasurer", "advisor", "executive", "admin"].includes(
-      data.role.toLowerCase()
-    );
-    
-    const roleOptions = Array.from(
-      new Set(
-        ((tasksResult.data ?? []) as DashboardTask[])
-          .filter((task) => task.assign_type === "role")
-          .map((task) => task.assigned_to)
-      )
-    );
-    
-    const upcomingTasks = ((tasksResult.data ?? []) as DashboardTask[])
-      .filter((task) => {
-        if (!task.due_date) return false;
-    
-        const [year, month, day] = task.due_date.split("-").map(Number);
-        const dueDate = new Date(year, month - 1, day);
-    
-        const isDueSoon = dueDate >= today && dueDate <= twoWeeksFromNow;
+  const twoWeeksFromNow = new Date(today);
+  twoWeeksFromNow.setDate(today.getDate() + 14);
 
-        const matchesSelectedRole =
-          taskRole === "all" ||
-          task.assigned_to.toLowerCase() === taskRole.toLowerCase();
+  const canSeeAllTasks = ["treasurer", "advisor", "executive", "admin"].includes(
+    data.role.toLowerCase()
+  );
 
-        const memberCanSeeTask =
-          task.assign_type === "role" &&
-          task.assigned_to.toLowerCase() === data.role.toLowerCase();
+  const roleOptions = Array.from(
+    new Set(
+      ((tasksResult.data ?? []) as DashboardTask[])
+        .filter((task) => task.assign_type === "role")
+        .map((task) => task.assigned_to)
+    )
+  );
 
-        return (
-          isDueSoon &&
-          (canSeeAllTasks ? matchesSelectedRole : memberCanSeeTask)
-        );
-      })
-      .sort((a, b) => {
-        const [ay, am, ad] = (a.due_date as string).split("-").map(Number);
-        const [by, bm, bd] = (b.due_date as string).split("-").map(Number);
-      
-        return (
-          new Date(ay, am - 1, ad).getTime() -
-          new Date(by, bm - 1, bd).getTime()
-        );
-      });
+  const upcomingTasks = ((tasksResult.data ?? []) as DashboardTask[])
+    .filter((task) => {
+      if (!task.due_date) return false;
+
+      const [year, month, day] = task.due_date.split("-").map(Number);
+      const dueDate = new Date(year, month - 1, day);
+
+      const isDueSoon = dueDate >= today && dueDate <= twoWeeksFromNow;
+
+      const matchesSelectedRole =
+        taskRole === "all" ||
+        task.assigned_to.toLowerCase() === taskRole.toLowerCase();
+
+      const memberCanSeeTask =
+        task.assign_type === "role" &&
+        task.assigned_to.toLowerCase() === data.role.toLowerCase();
+
+      return (
+        isDueSoon &&
+        (canSeeAllTasks ? matchesSelectedRole : memberCanSeeTask)
+      );
+    })
+    .sort((a, b) => {
+      const [ay, am, ad] = (a.due_date as string).split("-").map(Number);
+      const [by, bm, bd] = (b.due_date as string).split("-").map(Number);
+
+      return (
+        new Date(ay, am - 1, ad).getTime() -
+        new Date(by, bm - 1, bd).getTime()
+      );
+    });
   const canAccessFiles = canViewFiles(data.role);
   const canExport = canExportTransactions(data.role);
 
   return ( //changed for layout - prabh
     <main className="lb-page min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       <Navbar
-          currentUserRole={data.role}
-          organizations={data.organizations}
-          currentOrgId={data.orgId}
-          currentOrgName={
-            data.organizations.find(org => org.org_id === data.orgId)?.org_name || "Unknown Org"
-          }
-          basePath="/"
-          logoSrc={currentOrg?.logo_url || null}
-          pageTitle="Dashboard"
-        />
+        currentUserRole={data.role}
+        organizations={data.organizations}
+        currentOrgId={data.orgId}
+        currentOrgName={
+          data.organizations.find(org => org.org_id === data.orgId)?.org_name || "Unknown Org"
+        }
+        basePath="/"
+        logoSrc={currentOrg?.logo_url || null}
+        pageTitle="Dashboard"
+      />
       <div className="mx-auto max-w-7xl px-6 py-8 lg:px-8">
 
         {data.scope === "organization" ? (
@@ -573,9 +573,9 @@ export default async function DashboardPage({
                 label="Expenses"
                 value={formatCurrency(data.summary.expenses)}
               />
-              <StatCard 
-                label="Net" 
-                value={formatCurrency(data.summary.net)} 
+              <StatCard
+                label="Net"
+                value={formatCurrency(data.summary.net)}
               />
 
               <LinkCard
@@ -603,14 +603,14 @@ export default async function DashboardPage({
                 />
               )}
             </section>
-            
+
             <TasksSection
               orgId={data.orgId}
               tasks={upcomingTasks}
               canSeeAllTasks={canSeeAllTasks}
               roleOptions={data.roleOptions}
               selectedRole={taskRole}
-              />
+            />
             <TransactionsTable
               title="Recent Organization Transactions"
               transactions={data.recentTransactions}
@@ -645,11 +645,11 @@ export default async function DashboardPage({
 
             <TasksSection
               orgId={data.orgId}
-              tasks={upcomingTasks} 
+              tasks={upcomingTasks}
               canSeeAllTasks={canSeeAllTasks}
               roleOptions={data.roleOptions}
               selectedRole={taskRole}
-              />
+            />
             <TransactionsTable
               title="My Recent Transactions"
               transactions={data.recentTransactions}

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -84,12 +84,6 @@ function QuotesPageContent() {
         setUserRole(role)
     }
 
-    useEffect(() => {
-        fetchQuotes()
-        fetchUserRole()
-        fetchOrganizations()
-    }, [])
-
     async function fetchOrganizations() {
         if (!orgID) return;
         const supabase = createClient();
@@ -110,6 +104,12 @@ function QuotesPageContent() {
         }));
         setOrganizations(orgList);
     }
+
+    useEffect(() => {
+        fetchQuotes()
+        fetchUserRole()
+        fetchOrganizations()
+    }, [])
 
     async function handleAddQuote() {
         if (!vendor || !memo || !amount || !orgID) return

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { createClient } from "@/lib/supabase/client";
+import OrgDropDown from "@/components/OrgDropDown";
 import { useEffect, useState, Suspense } from "react"
 import { addQuote, getQuotes, acceptQuote, deleteQuote, getCurrentUserRole } from "./actions"
 import BackButton from "@/components/BackButton"
@@ -17,6 +19,12 @@ function SkeletonPulse({ className = "" }: SkeletonPulseProps) {
     )
 }
 
+type OrgOption = {
+    org_id: string;
+    org_name: string;
+    role: string;
+};
+
 function QuotesPageContent() {
     const [quotes, setQuotes] = useState<{
         quotes_id: number
@@ -29,6 +37,7 @@ function QuotesPageContent() {
     const searchParams = useSearchParams()
     const orgID = searchParams.get('orgId')
 
+    const [organizations, setOrganizations] = useState<OrgOption[]>([]);
     const [vendor, setVendor] = useState("")
     const [memo, setMemo] = useState("")
     const [amount, setAmount] = useState("")
@@ -78,7 +87,29 @@ function QuotesPageContent() {
     useEffect(() => {
         fetchQuotes()
         fetchUserRole()
+        fetchOrganizations()
     }, [])
+
+    async function fetchOrganizations() {
+        if (!orgID) return;
+        const supabase = createClient();
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
+
+        const { data: memberships } = await supabase
+            .from("org_members")
+            .select("org_id, role, organizations(org_name)")
+            .eq("user_id", user.id);
+
+        if (!memberships) return;
+
+        const orgList: OrgOption[] = memberships.map((m: any) => ({
+            org_id: m.org_id,
+            org_name: m.organizations?.org_name ?? m.org_id,
+            role: m.role,
+        }));
+        setOrganizations(orgList);
+    }
 
     async function handleAddQuote() {
         if (!vendor || !memo || !amount || !orgID) return
@@ -111,10 +142,16 @@ function QuotesPageContent() {
             <div className="mx-auto max-w-3xl px-6 py-8 lg:px-8">
 
                 {/* Header */}
-                <div className="flex items-center justify-between mb-8">
+                <div className="flex items-center justify-between mb-6">
                     <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">Quotes</h1>
                     <BackButton />
                 </div>
+
+                {organizations.length > 1 && orgID && (
+                    <div className="mb-6">
+                        <OrgDropDown organizations={organizations} currentOrgId={orgID} basePath="/quotes" />
+                    </div>
+                )}
 
                 {/* Access denied state - only show after role has been fetched */}
                 {!loading && userRole !== null && !canView && (

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -49,7 +49,7 @@ export default function ResetPasswordPage() {
                     Set a new password
                 </h1>
                 <p className="text-sm text-gray-500 dark:text-neutral-400 mb-6">
-                    Choose a new password for your account. You'll be redirected to login after.
+                    Choose a new password for your account. You&apos;ll be redirected to login after.
                 </p>
 
                 <div className="flex flex-col gap-3">

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -40,39 +40,44 @@ export default function ResetPasswordPage() {
     }
 
     return (
-        <div>
-            <div className="mt-5 flex flex-col items-center justify-center gap-3">
-                <h1 className="text-xl font-semibold mb-2">Set a new password</h1>
-                <p className="text-sm text-neutral-400 max-w-sm text-center mb-2">
-                    Choose a new password for your account. You&apos;ll be redirected to login after.
+        <main className="min-h-screen bg-background text-foreground flex items-center justify-center px-6">
+            <section className="w-full max-w-sm rounded-2xl border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] p-8 shadow-[0_0_20px_rgba(255,255,255,0.05)] backdrop-blur-sm">
+                <p className="text-xs uppercase tracking-[0.18em] text-gray-500 dark:text-neutral-400 mb-1">
+                    TreasuryHub
+                </p>
+                <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white mb-2">
+                    Set a new password
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-neutral-400 mb-6">
+                    Choose a new password for your account. You'll be redirected to login after.
                 </p>
 
-                <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
-                    placeholder="New password"
-                />
+                <div className="flex flex-col gap-3">
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="New password"
+                    />
+                    <input
+                        type="password"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        className="w-full rounded-lg border border-gray-200 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        placeholder="Confirm new password"
+                    />
+                    <button
+                        onClick={handleSubmit}
+                        disabled={loading}
+                        className="w-full rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 transition hover:bg-blue-500/20 disabled:opacity-50"
+                    >
+                        {loading ? "Updating..." : "Update password"}
+                    </button>
+                </div>
 
-                <input
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="border border-gray-300 rounded p-2 w-72 text-gray-900 bg-gray-100 focus:border-blue-500 focus:outline-none dark:border-white/[0.2] dark:bg-white/[0.05] dark:text-white"
-                    placeholder="Confirm new password"
-                />
-
-                <button
-                    onClick={handleSubmit}
-                    disabled={loading}
-                    className="border border-gray-300 rounded p-2 text-gray-900 hover:bg-gray-100 disabled:opacity-50 dark:border-white/[0.2] dark:text-white dark:hover:bg-white/[0.1]"
-                >
-                    {loading ? "Updating..." : "Update password"}
-                </button>
-
-                {error && <p className="text-red-500 text-sm">{error}</p>}
-            </div>
-        </div>
+                {error && <p className="mt-3 text-sm text-red-500 dark:text-red-400">{error}</p>}
+            </section>
+        </main>
     )
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { createClient } from "@/lib/supabase/server"
 import { updateDisplayName } from "./actions"
 import ThemeToggle from "@/components/ThemeToggle"
+import BackButton from "@/components/BackButton"
 
 // Account-level settings page (not org-scoped).
 // Lives at /settings, accessible from the navbar regardless of which org the
@@ -36,16 +37,19 @@ export default async function SettingsPage() {
     return (
         <main className="min-h-screen bg-background text-foreground">
             <div className="mx-auto max-w-2xl px-6 py-10">
-                <div className="mb-8">
-                    <p className="text-xs uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-400">
-                        Account Settings
-                    </p>
-                    <h1 className="mt-2 text-3xl font-semibold tracking-tight">
-                        Your Account
-                    </h1>
-                    <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-                        Manage your profile, appearance, and password.
-                    </p>
+                <div className="mb-8 flex items-start justify-between gap-4">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-400">
+                            Account Settings
+                        </p>
+                        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+                            Your Account
+                        </h1>
+                        <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+                            Manage your profile, appearance, and password.
+                        </p>
+                    </div>
+                    <BackButton />
                 </div>
 
                 {/* Profile info */}
@@ -117,15 +121,6 @@ export default async function SettingsPage() {
                         </Link>
                     </div>
                 </section>
-
-                <div className="mt-8">
-                    <Link
-                        href="/"
-                        className="text-sm text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                        &larr; Back to dashboard
-                    </Link>
-                </div>
             </div>
         </main>
     )

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { createClient } from "@/lib/supabase/client";
+import OrgDropDown from "@/components/OrgDropDown";
 import { Suspense, useEffect, useState, useRef } from "react";
 import BackButton from "@/components/BackButton";
 import Skeleton from "@/components/Skeleton";
@@ -32,6 +34,12 @@ type DatabaseTask = {
   notify_days_before?: number | null;
 };
 
+type OrgOption = {
+  org_id: string;
+  org_name: string;
+  role: string;
+};
+
 type SkeletonPulseProps = { className?: string };
 function SkeletonPulse({ className = "" }: SkeletonPulseProps) {
   return (
@@ -47,6 +55,7 @@ const selectClass =
 
 function TasksPageContent() {
   const orgId = useSearchParams().get("orgId");
+  const [organizations, setOrganizations] = useState<OrgOption[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -102,6 +111,30 @@ function TasksPageContent() {
     };
 
     fetchTasks();
+  }, [orgId]);
+
+  useEffect(() => {
+    async function fetchOrganizations() {
+      if (!orgId) return;
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: memberships } = await supabase
+        .from("org_members")
+        .select("org_id, role, organizations(org_name)")
+        .eq("user_id", user.id);
+
+      if (!memberships) return;
+
+      const orgList: OrgOption[] = memberships.map((m: any) => ({
+        org_id: m.org_id,
+        org_name: m.organizations?.org_name ?? m.org_id,
+        role: m.role,
+      }));
+      setOrganizations(orgList);
+    }
+    fetchOrganizations();
   }, [orgId]);
 
   const isValidFutureDate = (dateString: string) => {
@@ -202,10 +235,16 @@ function TasksPageContent() {
       <div className="mx-auto max-w-7xl px-6 py-8 lg:px-8">
 
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-white">Task List</h1>
           <BackButton />
         </div>
+
+        {organizations.length > 1 && orgId && (
+          <div className="mb-6">
+            <OrgDropDown organizations={organizations} currentOrgId={orgId} basePath="/tasks" />
+          </div>
+        )}
 
         {/* Upcoming alerts banner */}
         {getNotifications(tasks).length > 0 && (

--- a/src/app/transaction/loading.tsx
+++ b/src/app/transaction/loading.tsx
@@ -3,21 +3,21 @@
 import TransactionTable from "./ui/table";
 
 // base function used by all other skeleton components
-function SkeletonPulse({ className = "" }: { className?: string }){
-    return(
-        <div className={`animate-pulse rounded-md bg-white/[0.07] ${className}`} />
+function SkeletonPulse({ className = "" }: { className?: string }) {
+    return (
+        <div className={`animate-pulse rounded-md bg-gray-200 dark:bg-white/[0.07] ${className}`} />
     );
 }
 
 // PageHeaderSkeleton - placeholder for the page header
-function PageHeaderSkeleton(){
-    return(
+function PageHeaderSkeleton() {
+    return (
         <div className="flex items-center justify-between">
             <div>
                 <SkeletonPulse className="h-7 w-40 mb-1" />
                 <SkeletonPulse className="h-4 w-64" />
             </div>
-            
+
             <SkeletonPulse className="h-10 w-44 rounded-xl" />
         </div>
     );
@@ -28,29 +28,29 @@ function PageHeaderSkeleton(){
 const TABLE_ROW_COUNT = 10;
 
 const COLUMNS: { label: string; width: string; align?: "right" }[] = [
-    { label: "Date",        width: "w-24" },
+    { label: "Date", width: "w-24" },
     { label: "Description", width: "w-56" },
-    { label: "Category",    width: "w-28" },
-    { label: "Type",        width: "w-20" },
-    { label: "Amount",      width: "w-20", align: "right" },
-    { label: "Status",      width: "w-24" },
-    { label: "Actions",     width: "w-8",  align: "right" },
+    { label: "Category", width: "w-28" },
+    { label: "Type", width: "w-20" },
+    { label: "Amount", width: "w-20", align: "right" },
+    { label: "Status", width: "w-24" },
+    { label: "Actions", width: "w-8", align: "right" },
 ];
 
 // TransactionTableSkeleton - placeholder for the <TransactionTable> component
-function TransactionsTableSkeleton(){
-    return(
+function TransactionsTableSkeleton() {
+    return (
         <div
             className="
-                rounded-2x1
-                border border-white/[0.12]
-                bg-white/[0.03]
+                rounded-2xl
+                border border-gray-200 dark:border-white/[0.12]
+                bg-white dark:bg-white/[0.03]
                 backdrop-blur-sm
                 shadow-[0_0_20px_rgba(255,255,255,0.05)]
                 overflow-hidden
             "
         >
-            <div className="flex items-center justify-between gap-4 p-4 border-b border-white/[0.08]">
+            <div className="flex items-center justify-between gap-4 p-4 border-b border-gray-200 dark:border-white/[0.08]">
                 <SkeletonPulse className="h-9 w-56 rounded-xl" />
                 <div className="flex items-center gap-2">
                     <SkeletonPulse className="h-9 w-24 rounded-xl" />
@@ -61,14 +61,14 @@ function TransactionsTableSkeleton(){
             <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
                     <thead>
-                        <tr className="border-b border-white/[0.12]">
+                        <tr className="border-b border-gray-200 dark:border-white/[0.12]">
                             {COLUMNS.map(({ label, align }) => (
                                 <th
                                     key={label}
                                     className={`
                                         px-4 py-3
                                         text-xs uppercase tracking-[0.16em]
-                                        text-neutral-500 font-medium
+                                        text-gray-500 dark:text-neutral-500 font-medium
                                         ${align === "right" ? "text-right" : "text-left"}
                                     `}
                                 >
@@ -77,13 +77,13 @@ function TransactionsTableSkeleton(){
                             ))}
                         </tr>
                     </thead>
-                    
+
                     {/* shimmer stuff */}
                     <tbody>
                         {Array.from({ length: TABLE_ROW_COUNT }).map((_, rowIndex) => (
                             <tr
                                 key={rowIndex}
-                                className="border-b border-white/[0.06] last:border-0"
+                                className="border-b border-gray-100 dark:border-white/[0.06] last:border-0"
                             >
                                 {COLUMNS.map(({ label, width, align }) => (
                                     <td
@@ -91,7 +91,7 @@ function TransactionsTableSkeleton(){
                                         className={`px-4 py-3 ${align === "right" ? "text-right" : ""}`}
                                     >
                                         <SkeletonPulse className={`h-4 ${width} ${align === "right" ? "ml-auto" : ""}`}
-                                    />
+                                        />
                                     </td>
                                 ))}
                             </tr>
@@ -99,9 +99,9 @@ function TransactionsTableSkeleton(){
                     </tbody>
                 </table>
             </div>
-            
+
             {/* mimics row count label */}
-            <div className="flex items-center justify-between gap-4 px-4 py-3 border-t border-white/[0.08]">
+            <div className="flex items-center justify-between gap-4 px-4 py-3 border-t border-gray-200 dark:border-white/[0.08]">
                 <SkeletonPulse className="h-4 w-28" />
                 {/* next buttons */}
                 <div className="flex items-center gap-2">
@@ -115,9 +115,9 @@ function TransactionsTableSkeleton(){
 }
 
 // TransactionPageLoading — the default export consumed by Next.js as the Suspense fallback for the /transaction route
-export default function TransactionPageLoading(){
-    return(
-        <main className="max-w-7x1 mx-auto px-4 py-8 pb-16">
+export default function TransactionPageLoading() {
+    return (
+        <main className="max-w-7xl mx-auto px-4 py-8 pb-16">
             <div className="space-y-6">
                 <PageHeaderSkeleton />
                 <TransactionsTableSkeleton />

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -75,7 +75,7 @@ export default function FileViewer({ filePath, fileName, mimeType, onClose }: Pr
 
         return (
             <div className="flex flex-col items-center justify-center h-full gap-4">
-                <p className="text-black">This file type cannot be previewed inline.</p>
+                <p className="text-black dark:text-white">This file type cannot be previewed inline.</p>
                 <a href={url} download={fileName} className="bg-blue-600 text-white px-4 py-2 rounded">
                     Download {fileName}
                 </a>
@@ -85,22 +85,22 @@ export default function FileViewer({ filePath, fileName, mimeType, onClose }: Pr
 
     return (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg w-full max-w-4xl h-[80vh] flex flex-col">
+            <div className="bg-white dark:bg-neutral-900 rounded-lg w-full max-w-4xl h-[80vh] flex flex-col">
 
                 {/* Header with filename and close button */}
-                <div className="flex items-center justify-between p-4 border-b">
-                    <h2 className="text-lg font-semibold text-black">{fileName}</h2>
+                <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-white/[0.12]">
+                    <h2 className="text-lg font-semibold text-black dark:text-white">{fileName}</h2>
                     <button
                         onClick={onClose}
-                        className="text-black hover:text-gray-600 text-xl font-bold"
+                        className="text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-400 text-xl font-bold"
                     >
                         ✕
                     </button>
                 </div>
 
                 {/* File content area */}
-                <div className="flex-1 overflow-auto p-4">
-                    {loading && <p className="text-black">Loading file...</p>}
+                <div className="flex-1 overflow-auto p-4 flex items-center justify-center">
+                    {loading && <p className="text-black dark:text-white">Loading file...</p>}
                     {error && <p className="text-red-500">{error}</p>}
                     {!loading && !error && renderFile()}
                 </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,6 +33,11 @@ export default function Navbar({
   const canEditLogo = ["treasurer", "executive", "advisor", "admin"].includes(
     currentUserRole.toLowerCase()
   );
+
+
+
+
+
   return (
     <nav
       className="
@@ -124,6 +129,7 @@ export default function Navbar({
                 organizations={organizations}
                 currentOrgId={currentOrgId}
                 basePath={basePath}
+                showCurrentOrgName={false}
               />
             </div>
           </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,7 +80,7 @@ export default function Navbar({
             <button
               type="button"
               onClick={() =>
-                window.alert("Only treasurers and advisors can change the organization logo.")
+                window.alert("Only treasurers, executives, advisors, and admins can change the organization logo.")
               }
               title="You do not have permission to edit the logo"
               className="

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -24,6 +24,7 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath }: P
   const inputRef = useRef<HTMLInputElement>(null)
 
   const otherOrgs = organizations.filter((org) => org.org_id !== currentOrgId)
+  const currentOrg = organizations.find((org) => org.org_id === currentOrgId)
 
   const filtered = query.trim()
     ? otherOrgs.filter((org) =>
@@ -73,7 +74,7 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath }: P
           focus:outline-none
         "
       >
-        CHANGE ORGANIZATION
+        {currentOrg?.org_name ?? "Select organization"} ▾
       </button>
 
       {open && (

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -75,7 +75,7 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath, sho
           focus:outline-none
         "
       >
-        {showCurrentOrgName ? (currentOrg?.org_name ?? "Select organization") : "Change organization"} ▾
+        {showCurrentOrgName ? (currentOrg?.org_name ?? "Select organization") : "CHANGE ORGANIZATION"} ▾
       </button>
 
       {open && (

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -12,9 +12,10 @@ type Props = {
   }[]
   currentOrgId: string
   basePath: string // e.g. '/dashboard' or '/files'
+  showCurrentOrgName?: boolean // default true; set false when parent already shows org name
 }
 
-export default function OrgDropDown({ organizations, currentOrgId, basePath }: Props) {
+export default function OrgDropDown({ organizations, currentOrgId, basePath, showCurrentOrgName = true }: Props) {
   // Hide entirely if user has only one org (no other orgs to switch to)
 
   const router = useRouter()
@@ -74,7 +75,7 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath }: P
           focus:outline-none
         "
       >
-        {currentOrg?.org_name ?? "Select organization"} ▾
+        {showCurrentOrgName ? (currentOrg?.org_name ?? "Select organization") : "Change organization"} ▾
       </button>
 
       {open && (

--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -63,74 +63,77 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath, sho
       <button
         onClick={() => setOpen((prev) => !prev)}
         className="
-          lb-button
-          font-[var(--font-geist-sans)]
-          cursor-pointer rounded-lg
-          border border-white/[0.15]
-          bg-blue-600
-          px-3 py-1.5
-          text-xs font-medium tracking-wide text-neutral-200
-          transition
-          hover:border-white/[0.3] hover:bg-white/[0.07]
-          focus:outline-none
-        "
+              lb-button
+              font-[var(--font-geist-sans)]
+              cursor-pointer rounded-lg
+              border border-blue-700 dark:border-white/[0.15]
+              bg-blue-600
+              px-3 py-1.5
+              text-xs font-medium tracking-wide text-white
+              transition
+              hover:border-blue-800 dark:hover:border-white/[0.3]
+              hover:bg-blue-700 dark:hover:bg-white/[0.07]
+              focus:outline-none
+            "
       >
         {showCurrentOrgName ? (currentOrg?.org_name ?? "Select organization") : "CHANGE ORGANIZATION"} ▾
       </button>
 
-      {open && (
-        <div className="
+      {
+        open && (
+          <div className="
           absolute left-0 top-full z-50 mt-1 w-56
           rounded-lg border border-white/[0.15]
           bg-neutral-950 shadow-xl
         ">
-          {/* Search input */}
-          <div className="border-b border-white/[0.1] p-2">
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && filtered.length > 0) {
-                  handleSelect(filtered[0].org_id)
-                }
-              }}
-              placeholder="Search organizations..."
-              className="
+            {/* Search input */}
+            <div className="border-b border-white/[0.1] p-2">
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && filtered.length > 0) {
+                    handleSelect(filtered[0].org_id)
+                  }
+                }}
+                placeholder="Search organizations..."
+                className="
                 w-full rounded-md
                 bg-white/[0.06]
                 px-2 py-1.5
                 text-xs text-neutral-200 placeholder-neutral-500
                 focus:outline-none focus:ring-1 focus:ring-white/20
               "
-            />
-          </div>
+              />
+            </div>
 
-          {/* Options */}
-          <ul className="max-h-52 overflow-y-auto py-1">
-            {filtered.length > 0 ? (
-              filtered.map((org) => (
-                <li key={org.org_id}>
-                  <button
-                    onClick={() => handleSelect(org.org_id)}
-                    className="
+            {/* Options */}
+            <ul className="max-h-52 overflow-y-auto py-1">
+              {filtered.length > 0 ? (
+                filtered.map((org) => (
+                  <li key={org.org_id}>
+                    <button
+                      onClick={() => handleSelect(org.org_id)}
+                      className="
                       w-full px-3 py-2 text-left
                       text-xs text-neutral-200
                       hover:bg-white/[0.08]
                       transition-colors
                     "
-                  >
-                    {org.org_name}
-                  </button>
-                </li>
-              ))
-            ) : (
-              <li className="px-3 py-2 text-xs text-neutral-500">No results</li>
-            )}
-          </ul>
-        </div>
-      )}
-    </div>
+                    >
+                      {org.org_name}
+                    </button>
+                  </li>
+                ))
+              ) : (
+                <li className="px-3 py-2 text-xs text-neutral-500">No results</li>
+              )}
+            </ul>
+          </div>
+        )
+      }
+    </div >
   )
 }

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -75,20 +75,20 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
 
     return (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg p-6 w-full max-w-md">
-                <h2 className="text-lg font-semibold mb-4 text-black">Upload File</h2>
+            <div className="bg-white dark:bg-neutral-900 rounded-lg p-6 w-full max-w-md">
+                <h2 className="text-lg font-semibold mb-4 text-black dark:text-white">Upload File</h2>
 
                 {/* Toggle between receipt and document */}
                 <div className="flex gap-4 mb-4">
                     <button
                         onClick={() => setFileType('receipt')}
-                        className={`flex-1 py-2 rounded border ${fileType === 'receipt' ? 'bg-blue-600 text-white' : 'border-gray-300 text-black'}`}
+                        className={`flex-1 py-2 rounded border ${fileType === 'receipt' ? 'bg-blue-600 text-white border-blue-600' : 'border-gray-300 dark:border-white/[0.15] text-black dark:text-white'}`}
                     >
                         Receipt
                     </button>
                     <button
                         onClick={() => setFileType('document')}
-                        className={`flex-1 py-2 rounded border ${fileType === 'document' ? 'bg-blue-600 text-white' : 'border-gray-300 text-black'}`}
+                        className={`flex-1 py-2 rounded border ${fileType === 'document' ? 'bg-blue-600 text-white border-blue-600' : 'border-gray-300 dark:border-white/[0.15] text-black dark:text-white'}`}
                     >
                         Document
                     </button>
@@ -97,13 +97,13 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
                 {/* Optional transaction linking for both receipts and documents */}
                 {/* NOTE: transaction labels will improve when transaction table has display fields */}
                 <div className="mb-4">
-                    <label className="block text-sm text-black mb-1">
+                    <label className="block text-sm text-black dark:text-white mb-1">
                         Link to Transaction (optional)
                     </label>
                     <select
                         value={selectedTransaction}
                         onChange={(e) => setSelectedTransaction(e.target.value)}
-                        className="w-full border border-gray-300 rounded p-2 text-black"
+                        className="w-full border border-gray-300 dark:border-white/[0.15] bg-white dark:bg-neutral-800 rounded p-2 text-black dark:text-white"
                     >
                         <option value="">No transaction</option>
                         {transactions.map((t) => (
@@ -128,7 +128,7 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
                 {/* Clicking this label opens the file picker */}
                 <label
                     htmlFor="file-input"
-                    className="block w-full mb-4 p-4 border-2 border-dashed border-gray-300 rounded text-center cursor-pointer hover:border-blue-400 text-black"
+                    className="block w-full mb-4 p-4 border-2 border-dashed border-gray-300 dark:border-white/[0.15] rounded text-center cursor-pointer hover:border-blue-400 text-black dark:text-white"
                 >
                     {file ? file.name : 'Click to choose a file'}
                 </label>
@@ -138,14 +138,14 @@ export default function UploadModal({ orgId, transactionId, onSuccess, onClose }
                 <div className="flex gap-3">
                     <button
                         onClick={onClose}
-                        className="flex-1 py-2 rounded border border-gray-300 text-black"
+                        className="flex-1 py-2 rounded border border-gray-300 dark:border-white/[0.15] text-black dark:text-white hover:bg-gray-100 dark:hover:bg-white/[0.05]"
                     >
                         Cancel
                     </button>
                     <button
                         onClick={handleUpload}
                         disabled={!file || uploading}
-                        className="flex-1 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+                        className="flex-1 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
                     >
                         {uploading ? 'Uploading...' : 'Upload'}
                     </button>


### PR DESCRIPTION
## Description
Fixes the production-only sign-out bug and resolves a list of dark/light mode visual issues, missing org context on side pages, and miscellaneous polish before final demo.

---

## Issues Addressed
Closes #140 

---

## Changes
- Added `{ status: 303 }` to signout redirect so the POST converts to a GET on `/login` (production-only bug)
- Replaced transparent dark-mode dialog rule in `globals.css` with solid `#0a0a0a` so the edit task dialog renders correctly
- Added `color-scheme: light/dark` to `:root` and `.dark` so the native date picker calendar matches the app theme
- Added light-mode variants to dashboard buttons (View Transactions, Open Tasks, Export CSV) so they aren't invisible on white backgrounds
- Added light-mode variants to the "Change Organization" dropdown button
- Updated skeleton loaders in `dashboard/loading.tsx` and `transaction/loading.tsx` with light-mode borders and backgrounds, and removed forced `bg-black text-white` from the dashboard skeleton root
- Fixed `rounded-2x1` and `max-w-7x1` typos in the loading files
- Added `dark:` variants throughout `UploadModal.tsx` and `FileViewer.tsx` so both modals respect dark mode
- Added `flex items-center justify-center` to the file viewer content area so images center properly
- Added org membership fetch and `<OrgDropDown>` to Tasks and Quotes pages, matching the pattern used by Audit and Files
- Updated `OrgDropDown` button label to show the current org name; added a `showCurrentOrgName` prop so the Navbar's dropdown stays as "Change organization" to avoid redundancy
- Replaced bare `<div>` layout on `/forgot-password` and `/reset-password` with the centered card layout used by login and register
- Moved settings page back button from the bottom to the top-right of the header
- Changed org members logo wrapper from `rounded-full` to `rounded-2xl` and image from `object-cover` to `object-contain` so logos aren't cropped into circles
- Updated stale Navbar tooltip text to reflect actual logo-edit permissions (treasurers, executives, advisors, admins)

---

## How to Test
1. Sign out on the Vercel preview build — should redirect cleanly to `/login` instead of breaking
2. Toggle light mode on the dashboard — every card border, button, and skeleton placeholder should remain visible
3. Open `/files`, click "Upload File" in dark mode — modal background and text should be properly themed
4. View an image file from `/files` — image should be centered in the viewer, modal should respect theme
5. Visit `/tasks` and `/quotes` as a multi-org user — each page should show the org dropdown at the top
6. Visit the dashboard as a multi-org user — the navbar dropdown should still say "Change organization" (no redundancy with the org name shown next to it)
7. Visit `/forgot-password` and `/reset-password` — both should show the centered card matching `/login`
8. Visit `/settings` — back button should be top-right, not at the bottom
9. As a `member`, click the navbar logo — alert should mention treasurers, executives, advisors, and admins

---

## Screenshots
Check out the vercel preview, too many screenshots to include lol

---

## Checklist
- [X] Tested locally
- [X] Tested everything in Vercel Preview
- [X] No errors in console