### PR TITLE
Fix dark/light mode styling issues for organization dropdown and task role filter

### DIFF
--- a/src/components/OrgDropDown.tsx
+++ b/src/components/OrgDropDown.tsx
@@ -82,12 +82,12 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath, sho
       {
         open && (
           <div className="
-          absolute left-0 top-full z-50 mt-1 w-56
-          rounded-lg border border-white/[0.15]
-          bg-neutral-950 shadow-xl
-        ">
+            absolute left-0 top-full z-50 mt-1 w-56
+            rounded-lg border border-gray-200 dark:border-white/[0.15]
+            bg-white dark:bg-neutral-950 shadow-xl
+          ">
             {/* Search input */}
-            <div className="border-b border-white/[0.1] p-2">
+            <div className="border-b border-gray-200 dark:border-white/[0.1] p-2">
               <input
                 ref={inputRef}
                 type="text"
@@ -100,12 +100,13 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath, sho
                 }}
                 placeholder="Search organizations..."
                 className="
-                w-full rounded-md
-                bg-white/[0.06]
-                px-2 py-1.5
-                text-xs text-neutral-200 placeholder-neutral-500
-                focus:outline-none focus:ring-1 focus:ring-white/20
-              "
+            w-full rounded-md
+            bg-white dark:bg-white/[0.06]
+            px-2 py-1.5
+            text-xs text-gray-900 dark:text-neutral-200
+            placeholder-gray-400 dark:placeholder-neutral-500
+            focus:outline-none focus:ring-1 focus:ring-gray-300 dark:focus:ring-white/20
+          "
               />
             </div>
 
@@ -117,18 +118,20 @@ export default function OrgDropDown({ organizations, currentOrgId, basePath, sho
                     <button
                       onClick={() => handleSelect(org.org_id)}
                       className="
-                      w-full px-3 py-2 text-left
-                      text-xs text-neutral-200
-                      hover:bg-white/[0.08]
-                      transition-colors
-                    "
+                  w-full px-3 py-2 text-left
+                  text-xs text-gray-700 dark:text-neutral-200
+                  hover:bg-gray-100 dark:hover:bg-white/[0.08]
+                  transition-colors
+                "
                     >
                       {org.org_name}
                     </button>
                   </li>
                 ))
               ) : (
-                <li className="px-3 py-2 text-xs text-neutral-500">No results</li>
+                <li className="px-3 py-2 text-xs text-gray-500 dark:text-neutral-500">
+                  No results
+                </li>
               )}
             </ul>
           </div>

--- a/src/components/TaskRoleFilter.tsx
+++ b/src/components/TaskRoleFilter.tsx
@@ -22,17 +22,26 @@ export default function TaskRoleFilter({
         className="
           rounded-xl
           border border-gray-200 dark:border-white/[0.2]
-          bg-white dark:bg-white/[0.05]
+          bg-white dark:bg-neutral-900
           px-4 py-2
-          text-sm font-medium text-gray-900 dark:text-white
+          text-sm font-medium
+          text-gray-900 dark:text-white
           transition
           hover:border-gray-300 dark:hover:border-white/[0.35]
           hover:bg-gray-50 dark:hover:bg-white/[0.08]
         "
+        style={{ colorScheme: "light dark" }}
       >
-        <option value="all">All roles</option>
+        <option value="all" className="bg-white text-gray-900 dark:bg-neutral-900 dark:text-white">
+          All roles
+        </option>
+
         {roleOptions.map((role) => (
-          <option key={role} value={role}>
+          <option
+            key={role}
+            value={role}
+            className="bg-white text-gray-900 dark:bg-neutral-900 dark:text-white"
+          >
             {role}
           </option>
         ))}


### PR DESCRIPTION
## Description

Fix dark/light mode styling issues for organization dropdown and task role filter

---

## Issues Addressed

Closes #154

---

## Changes

* Updated OrgDropDown menu panel, search input, and options to support both light and dark mode
* Fixed TaskRoleFilter `<select>` to properly render in dark mode using `color-scheme` and theme-aware styles
* Added explicit styling to `<option>` elements to prevent unreadable text in dark mode

---

## How to Test

1. Switch between light mode and dark mode
2. Open the organization dropdown and verify background/text are readable in both modes
3. Use the task role filter dropdown and confirm options are visible and readable in both modes

---

## Screenshots

Before:
<img width="524" height="401" alt="image" src="https://github.com/user-attachments/assets/ae6f534e-766e-477d-85ca-3fad0a025877" />
<img width="823" height="161" alt="image" src="https://github.com/user-attachments/assets/42cfa84e-9e3f-47a4-bbae-b841b2b9cb26" />

After: 
<img width="384" height="207" alt="image" src="https://github.com/user-attachments/assets/9f1d8560-f1e0-45e6-b5a9-d79c95b93aa1" />
<img width="1219" height="412" alt="image" src="https://github.com/user-attachments/assets/fe7f15a4-333e-4eb9-a3fe-2cc5500ffec7" />

---

## Checklist

* [x] Tested locally
* [x] Tested everything in Vercel Preview
* [x] No errors in console
